### PR TITLE
Add tests for disabling CPU and memory limits

### DIFF
--- a/Tests/Config.ps1
+++ b/Tests/Config.ps1
@@ -13,6 +13,7 @@ $global:config.scope = @{
     cluster = '*'
     host    = '*'
     vm      = '*'
+
 }
 
 <########################################################################################
@@ -59,11 +60,15 @@ $global:config.host = @{
         VM Settings
         snapretention = [int] Allowed number of days for a VM snapshot to exist
         allowconnectedcdrom = [bool] $true or $false
+        allowcpulimit = [bool] $true or $false
+        allowmemorylimit = [bool] $true or $false
 #>
 
 $global:config.vm = @{
     snapretention       = 9999
     allowconnectedcdrom = $false
+    allowcpulimit       = $false
+    allowmemorylimit    = $false
 }
 
 <########################################################################################

--- a/Tests/Disable-Limit.Tests.ps1
+++ b/Tests/Disable-Limit.Tests.ps1
@@ -1,0 +1,81 @@
+#requires -Modules Pester
+#requires -Modules VMware.VimAutomation.Core
+
+
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory = $true,Position = 0,HelpMessage = 'Remediation toggle')]
+    [ValidateNotNullorEmpty()]
+    [switch]$Remediate,
+    [Parameter(Mandatory = $true,Position = 1,HelpMessage = 'Path to the configuration file')]
+    [ValidateNotNullorEmpty()]
+    [string]$Config
+)
+
+Process {
+    # Variables
+    Invoke-Expression -Command (Get-Item -Path $Config)
+    [bool]$allowcpulimit = $global:config.vm.allowcpulimit
+    [bool]$allowmemorylimit = $global:config.vm.allowmemorylimit
+
+    # Tests
+    # CPU Limits 
+    If (-not $allowcpulimit) {
+        Describe -Name 'VM Configuration: CPU Limit' -Fixture {
+            foreach ($VM in (Get-VM -Name $global:config.scope.vm)) 
+            {
+                It -name "$($VM.name) has no CPU limits configured" -test {
+                    [array]$value = $VM | Get-VMResourceConfiguration
+                    try 
+                    {
+                        $value.CpuLimitMhz  | Should Be -1
+                    }
+                    catch 
+                    {
+                        if ($Remediate) 
+                        {
+                            Write-Warning -Message $_
+                            Write-Warning -Message "Remediating $VM"
+
+                            $value | Set-VMResourceConfiguration -CpuLimitMhz $null
+                        }
+                        else 
+                        {
+                            throw $_
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    # Memory Limits 
+    If (-not $allowmemorylimit) {
+        Describe -Name 'VM Configuration: Memory Limit' -Fixture {
+            foreach ($VM in (Get-VM -Name $global:config.scope.vm)) 
+            {
+                It -name "$($VM.name) has no memory limits configured" -test {
+                    [array]$value = $VM | Get-VMResourceConfiguration
+                    try 
+                    {
+                        $value.MemLimitMB  | Should Be -1
+                    }
+                    catch 
+                    {
+                        if ($Remediate) 
+                        {
+                            Write-Warning -Message $_
+                            Write-Warning -Message "Remediating $VM"
+
+                            $value | Set-VMResourceConfiguration -MemLimitMB $null
+                        }
+                        else 
+                        {
+                            throw $_
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR add the possibility to allow or not to have CPU or memory limits on VM. If remediation is set to `True`, limits will be set to `unlimited`.

A new Pester test named  `Disable-Limit.Tests.ps1` has been created.

Two new parameters have been added to `config.ps1`:

``` Powershell
$global:config.vm = @{
    ....
    allowcpulimit       = $false
    allowmemorylimit    = $false
}
```