### PR TITLE
Add Tags to Describe blocks to make scoping easier

### DIFF
--- a/Tests/Delete-Snapshot.Tests.ps1
+++ b/Tests/Delete-Snapshot.Tests.ps1
@@ -14,7 +14,7 @@ Param(
 
 Process {
     # Tests
-    Describe -Name 'VM Configuration: Snaphot(s)' -Fixture {
+    Describe -Name 'VM Configuration: Snaphot(s)' -Tag @("vm") -Fixture {
         # Variables
         . $Config
         [int]$snapretention = $config.vm.snapretention

--- a/Tests/Disable-Limit.Tests.ps1
+++ b/Tests/Disable-Limit.Tests.ps1
@@ -15,7 +15,7 @@ Param(
 Process {
     # Tests
     # CPU Limits 
-    Describe -Name 'VM Configuration: CPU Limit' -Fixture {
+    Describe -Name 'VM Configuration: CPU Limit' -Tags @("vm") -Fixture {
         # Variables
         . $Config
         [bool]$allowcpulimit    = $config.vm.allowcpulimit
@@ -49,7 +49,7 @@ Process {
     }
 
     # Memory Limits 
-    Describe -Name 'VM Configuration: Memory Limit' -Fixture {
+    Describe -Name 'VM Configuration: Memory Limit'-Tag @("vm") -Fixture {
         # Variables
         . $Config
         [bool]$allowmemorylimit = $config.vm.allowmemorylimit

--- a/Tests/Disconnect-CDROM.Tests.ps1
+++ b/Tests/Disconnect-CDROM.Tests.ps1
@@ -14,7 +14,7 @@ Param(
 
 Process {
     # Tests
-    Describe -Name 'VM Configuration: CDROM status' -Fixture {
+    Describe -Name 'VM Configuration: CDROM status' -Tag @("vm") -Fixture {
         # Variables
         . $Config
         [bool]$allowconnectedcdrom = $config.vm.allowconnectedcdrom

--- a/Tests/Update-DNS.Tests.ps1
+++ b/Tests/Update-DNS.Tests.ps1
@@ -14,7 +14,7 @@ Param(
 
 Process {
     # Tests
-    Describe -Name 'Host Configuration: DNS Server(s)' -Fixture {
+    Describe -Name 'Host Configuration: DNS Server(s)' -Tag @("host")-Fixture {
         # Variables
         . $Config
         [array]$esxdns = $config.host.esxdns

--- a/Tests/Update-DRS.Tests.ps1
+++ b/Tests/Update-DRS.Tests.ps1
@@ -14,7 +14,7 @@ Param(
 
 Process {
     # Tests
-    Describe -Name 'Cluster Configuration: DRS Settings' -Fixture {
+    Describe -Name 'Cluster Configuration: DRS Settings' -Tags @("vcenter","cluster") -Fixture {
         # Variables
         . $Config
         [string]$drsmode = $config.cluster.drsmode

--- a/Tests/Update-NFS.Tests.ps1
+++ b/Tests/Update-NFS.Tests.ps1
@@ -14,7 +14,7 @@ Param(
 
 Process {
     # Tests
-    Describe -Name 'Host Configuration: NFS Advanced Configuration' -Fixture {
+    Describe -Name 'Host Configuration: NFS Advanced Configuration' -Tag @("host","storage","nfs") -Fixture {
         # Variables
         . $Config
         [System.Collections.Hashtable]$nfsadvconfig = $config.nfsadvconfig

--- a/Tests/Update-NTP.Tests.ps1
+++ b/Tests/Update-NTP.Tests.ps1
@@ -14,7 +14,7 @@ Param(
 
 Process {
     # Tests
-    Describe -Name 'Host Configuration: NTP Server(s)' -Fixture {
+    Describe -Name 'Host Configuration: NTP Server(s)' -Tags @("host") -Fixture {
         # Variables
         . $Config
         [array]$esxntp = $config.host.esxntp

--- a/Tests/Update-SSH.Tests.ps1
+++ b/Tests/Update-SSH.Tests.ps1
@@ -14,7 +14,7 @@ Param(
 
 Process {
     # Tests
-    Describe -Name 'Host Configuration: SSH Server' -Fixture {
+    Describe -Name 'Host Configuration: SSH Server' -Tags @("host")-Fixture {
         # Variables
         . $Config
         [bool]$sshenable = $config.host.sshenable

--- a/Tests/Update-Syslog.Tests.ps1
+++ b/Tests/Update-Syslog.Tests.ps1
@@ -14,7 +14,7 @@ Param(
 
 Process {
     # Tests
-    Describe -Name 'Host Configuration: Syslog Server' -Fixture {
+    Describe -Name 'Host Configuration: Syslog Server' -Tags @("host") -Fixture {
         # Variables
         . $Config
         [array]$esxsyslog = $config.host.esxsyslog


### PR DESCRIPTION
In larger environments one (or in this case I) might want to limit the scope of Pester tests to run.  As an example in one of my vCenters ( >350 hosts and  > 4000 vms) might want to run tests just against the clusters and hosts and not against VMs.  These changes use the Tags option on Describe blocks to give a way to control which tests get run. 

Part of this for me is decreasing the amount of time it takes to run the tests esp given the variability of our vm configuration.  

**Examples:**  
Invoke-Pester  **_-ExcludeTag vm_** -Script @{Path = '.\Vester\Tests'; Parameters = @{ Remediate = $false ; Config = '.\Vester\Tests\Config.ps1' }} 
_runs ALL tests other than those tagged with VM (in this case skips: snapshots and the CDROM checks)._  


Invoke-Pester  **_-Tag host_** -Script @{Path = '.\Vester\Tests'; Parameters = @{ Remediate = $false ; Config = '.\Vester\Tests\Config.ps1' }} 
_runs only tests that are tagged with host.  (in this case skips: snapshots and the CDROM checks on vms, as well as cluster DRS checks etc)._


 
