### PR TITLE
Nfs test

### DIFF
--- a/Tests/Update-NFS.Tests.ps1
+++ b/Tests/Update-NFS.Tests.ps1
@@ -14,7 +14,7 @@ Param(
 
 Process {
     # Tests
-    Describe -Name 'Host Configuration: NFS Advanced Configuration  - CRT ' -Tag @("host","storage","nfs") -Fixture {
+    Describe -Name 'Host Configuration: NFS Advanced Configuration' -Tag @("host","storage","nfs") -Fixture {
         # Variables
         . $Config
         [System.Collections.Hashtable]$nfsadvconfig = $config.nfsadvconfig

--- a/Tests/Update-NFS.Tests.ps1
+++ b/Tests/Update-NFS.Tests.ps1
@@ -14,22 +14,33 @@ Param(
 
 Process {
     # Tests
-    Describe -Name 'Host Configuration: NFS Advanced Configuration' -Tag @("host","storage","nfs") -Fixture {
+    Describe -Name 'Host Configuration: NFS Advanced Configuration  - CRT ' -Tag @("host","storage","nfs") -Fixture {
         # Variables
         . $Config
         [System.Collections.Hashtable]$nfsadvconfig = $config.nfsadvconfig
-
+        $compare = @()
+        $nfsadvconfig.Values | ForEach-Object -Process {
+            $compare += $_
+        }
         foreach ($server in (Get-VMHost -Name $config.scope.host).name) 
         {
+            $hostadvcfg = Get-AdvancedSetting -Entity $server
+            $hostadvsettings = @{}
+            foreach ($setting in $hostadvcfg) { 
+                $sname = $setting.name
+                $svalue = $setting.value
+                $hostadvsettings[$sname] = $svalue
+        }
+            $value =@()
+            $hostadv
+            foreach ($setting in $nfsadvconfig.Keys) {
+                if ($hostadvsettings.ContainsKey($setting)){
+                    $value += $hostadvsetting.$setting
+                } else { 
+                    #nop 
+                }
+            }
             It -name "$server NFS Settings" -test {
-                $value = @()
-                $nfsadvconfig.Keys | ForEach-Object -Process {
-                    $value += (Get-AdvancedSetting -Entity $server -Name $_).Value
-                }
-                $compare = @()
-                $nfsadvconfig.Values | ForEach-Object -Process {
-                    $compare += $_
-                }
                 try 
                 {
                     $value | Should Be $compare

--- a/Tests/Update-NFS.Tests.ps1
+++ b/Tests/Update-NFS.Tests.ps1
@@ -31,7 +31,7 @@ Process {
                 $svalue = $setting.value
                 $hostadvsettings[$sname] = $svalue
         }
-            $value =@()
+            $value =@() 
             $hostadv
             foreach ($setting in $nfsadvconfig.Keys) {
                 if ($hostadvsettings.ContainsKey($setting)){


### PR DESCRIPTION
Moved the Get-AdvancedSettings block outside of the IT block in order to speed up the tests. In my large environment this reduced each test from about 60 seconds to 12..... On smaller environments each test id down to about 1 second. 