### PR TITLE
Add tests against host syslog firewall exceptions

### DIFF
--- a/Configs/Config.Tests.ps1
+++ b/Configs/Config.Tests.ps1
@@ -49,9 +49,9 @@ Process {
         }
 
         It 'Contains proper settings for .host' {
-            $HostKeys = 'sshenable|sshwarn|esxntp|esxdns|searchdomains|esxsyslog'
+            $HostKeys = 'sshenable|sshwarn|esxntp|esxdns|searchdomains|esxsyslog|esxsyslogfirewallexception'
             $config.host.Keys | Should Match $HostKeys
-            $config.host.Keys.Count | Should Be 6
+            $config.host.Keys.Count | Should Be 7
             $config.host.Values | ForEach-Object {$_ | Should Not BeNullOrEmpty}
             $config.host.sshenable | Should BeOfType Bool
             $config.host.sshwarn | Should BeOfType Int
@@ -68,6 +68,7 @@ Process {
             $config.host.esxsyslog | ForEach-Object {
                 $_ | Should Not BeNullOrEmpty
             }
+            $config.host.esxsyslogfirewallexception | Should BeOfType Bool
         }
 
         It 'Contains proper settings for .vm' {

--- a/Configs/Config.ps1
+++ b/Configs/Config.ps1
@@ -46,6 +46,7 @@ $config.cluster = @{
         esxdns = [array] @('DNS Server 1', 'DNS Server 2 (optional)')
         searchdomains = [array] @('Domain 1', 'Domain 2 (optional)')
         esxsyslog = [array] @('tcp://ip_address:port')
+        esxsyslogfirewallexception = [bool] $true or $false
 #>
 
 
@@ -56,6 +57,7 @@ $config.host = @{
     esxdns        = @('172.17.48.11', '172.17.48.12')
     searchdomains = @('rubrik.demo')
     esxsyslog     = @('tcp://172.16.20.243:514')
+    esxsyslogfirewallexception  = [bool]$true
 }
 
 <########################################################################################

--- a/Tests/Update-Syslog.Tests.ps1
+++ b/Tests/Update-Syslog.Tests.ps1
@@ -44,7 +44,7 @@ Process {
             It -name "$($server.name) Host Syslog Firewall State" -test {
                 [array]$value = $server | Get-VMHostFirewallException -name syslog
                 try {
-                    $value.enabled | Should be $True
+                    $value.enabled | Should be $esxsyslogfirewallexception
                 }
                 catch {
                     if ($Remediate) 


### PR DESCRIPTION
Add test and remediation for host syslog firewall exceptions.

Modifications:

- Add test in update-syslog.Tests.ps1
- Add new variable in config.ps1 names $config.host.esxsyslogfirewallexception (if you got a better idea for the name...)
- Add test in Config.Tests.ps1 for testing against the new variable