### PR TITLE
Added Update-SMTP Check

### DIFF
--- a/Configs/Config.Tests.ps1
+++ b/Configs/Config.Tests.ps1
@@ -20,8 +20,12 @@ Process {
         }
 
         It 'Contains proper settings for .vcenter' {
-            $config.vcenter.Keys | Should Be 'vc'
+            $config.vcenter.Keys | Should Match 'vc|smtpsender|smtpport|smtpserver'
+            $config.vcenter.Keys.Count | Should Be 4
             $config.vcenter.Values | ForEach-Object {$_ | Should Not BeNullOrEmpty}
+            $config.vcenter.smtpsender | Should BeOfType String
+            $config.vcenter.smtpport | Should BeOfType Int
+            $config.vcenter.smtpserver | Should BeOfType String
             # Connect, unless a connection that matches the .vc definition is found
             If ($DefaultVIServer.Name -ne $config.vcenter.vc) {
                 # Optionally, un-comment the next line to ignore certificate warnings in the current session

--- a/Configs/Config.ps1
+++ b/Configs/Config.ps1
@@ -28,6 +28,9 @@ $config.scope = @{
 
 $config.vcenter = @{
     vc = [string]'172.17.48.17'
+    smtpsender = [string]'vcenter@domain.com'
+    smtpport = [int]'25'
+    smtpserver = [string]'mailserver.domain.com'
 }
 
 <########################################################################################

--- a/Configs/Config.ps1
+++ b/Configs/Config.ps1
@@ -21,6 +21,9 @@ $config.scope = @{
 <########################################################################################
         vCenter Settings
         vc = [string] vCenter IP Address
+        smtpsender = [string] SMTP Address used for emails sent from vCenter Server
+        smtpport = [int] Port used to connect to SMTP Server
+        smtpserver = [string] SMTP Server used by vCenter to relay emails
 #>
 
 $config.vcenter = @{

--- a/Tests/Update-SMTP.Tests.ps1
+++ b/Tests/Update-SMTP.Tests.ps1
@@ -20,7 +20,7 @@ Process {
 
         foreach ($VCServer in ($config.vcenter.vc)) 
         {
-        $VCMailSettings = Get-AdvancedSetting -Entity $VCServer -Name @('mail*')
+        $VCMailSettings = Get-AdvancedSetting -Entity $VCServer -Name mail.sender,mail.smtp.port,mail.smtp.server
 
             It -name "$($VCServer) SMTP Sender" -test {
                 $value = $VCMailSettings[0].value
@@ -45,7 +45,7 @@ Process {
 
 
             It -name "$($VCServer) SMTP Port" -test {
-                $value = $VCMailSettings[2].value
+                $value = $VCMailSettings[1].value
                 try 
                 {
                     $value | Should Be $SMTPPort
@@ -67,7 +67,7 @@ Process {
 
             
             It -name "$($VCServer) SMTP Server" -test {
-                $value = $VCMailSettings[3].value
+                $value = $VCMailSettings[2].value
                 try 
                 {
                     $value | Should Be $SMTPServer

--- a/Tests/Update-SMTP.Tests.ps1
+++ b/Tests/Update-SMTP.Tests.ps1
@@ -1,0 +1,83 @@
+﻿#requires -Modules Pester, VMware.VimAutomation.Core
+
+[CmdletBinding()]
+Param(
+    # Optionally fix all config drift that is discovered. Defaults to false (off)
+    [switch]$Remediate = $false,
+
+    # Optionally define a different config file to use. Defaults to Vester\Configs\Config.ps1
+    [string]$Config = (Split-Path $PSScriptRoot) + '\Configs\Config.ps1'
+)
+
+Process {
+    # Tests
+        # Variables
+        . $Config
+        [string]$SMTPSender = $config.vcenter.smtpsender
+        [int]$SMTPPort = $config.vcenter.smtpport
+        [string]$SMTPServer = $config.vcenter.smtpserver
+
+        foreach ($VCServer in ($Global:DefaultVIServers)) 
+        {
+            It -name "$($VCServer.name) SMTP Sender" -test {
+                try 
+                {
+                    $value | Should Be $SMTPSender
+                }
+                catch 
+                {
+                    if ($Remediate) 
+                    {
+                        Write-Warning -Message $_
+                        Write-Warning -Message "Remediating SMTP Sender on $($VCServer.name)"
+                    }
+                    else 
+                    {
+                        throw $_
+                    }
+                }
+            }
+
+
+            It -name "$($VCServer.name) SMTP Port" -test {
+                try 
+                {
+                    $value | Should Be $SMTPPort
+                }
+                catch 
+                {
+                    if ($Remediate) 
+                    {
+                        Write-Warning -Message $_
+                        Write-Warning -Message "Remediating SMTP Port on $($VCServer.name)"
+                    }
+                    else 
+                    {
+                        throw $_
+                    }
+                }
+            }
+
+            
+            It -name "$($VCServer.name) SMTP Server" -test {
+                try 
+                {
+                    $value | Should Be $SMTPServer
+                }
+                catch 
+                {
+                    if ($Remediate) 
+                    {
+                        Write-Warning -Message $_
+                        Write-Warning -Message "Remediating SMTP Server on $($VCServer.name)"
+                    }
+                    else 
+                    {
+                        throw $_
+                    }
+                }
+            }
+
+        }#End Foreach
+    }
+}

--- a/Tests/Update-SMTP.Tests.ps1
+++ b/Tests/Update-SMTP.Tests.ps1
@@ -18,11 +18,11 @@ Process {
         [int]$SMTPPort = $config.vcenter.smtpport
         [string]$SMTPServer = $config.vcenter.smtpserver
 
-        foreach ($VCServer in ($Global:DefaultVIServers)) 
+        foreach ($VCServer in ($config.vcenter.vc)) 
         {
-        $VCMailSettings = Get-AdvancedSetting -Entity $VCServer.name -Name @('mail*')
+        $VCMailSettings = Get-AdvancedSetting -Entity $VCServer -Name @('mail*')
 
-            It -name "$($VCServer.name) SMTP Sender" -test {
+            It -name "$($VCServer) SMTP Sender" -test {
                 $value = $VCMailSettings[0].value
                 try 
                 {
@@ -33,8 +33,8 @@ Process {
                     if ($Remediate) 
                     {
                         Write-Warning -Message $_
-                        Write-Warning -Message "Remediating SMTP Sender on $($VCServer.name)"
-                        Get-AdvancedSetting -Entity $VCServer.name -Name mail.sender | Set-AdvancedSetting -value $SMTPSender -Confirm:$false -ErrorAction Stop
+                        Write-Warning -Message "Remediating SMTP Sender on $($VCServer)"
+                        Get-AdvancedSetting -Entity $VCServer -Name mail.sender | Set-AdvancedSetting -value $SMTPSender -Confirm:$false -ErrorAction Stop
                     }
                     else 
                     {
@@ -44,7 +44,7 @@ Process {
             }
 
 
-            It -name "$($VCServer.name) SMTP Port" -test {
+            It -name "$($VCServer) SMTP Port" -test {
                 $value = $VCMailSettings[2].value
                 try 
                 {
@@ -55,8 +55,8 @@ Process {
                     if ($Remediate) 
                     {
                         Write-Warning -Message $_
-                        Write-Warning -Message "Remediating SMTP Port on $($VCServer.name)"
-                        Get-AdvancedSetting -Entity $VCServer.name -Name mail.smtp.port | Set-AdvancedSetting -value $SMTPPort -Confirm:$false -ErrorAction Stop
+                        Write-Warning -Message "Remediating SMTP Port on $($VCServer)"
+                        Get-AdvancedSetting -Entity $VCServer -Name mail.smtp.port | Set-AdvancedSetting -value $SMTPPort -Confirm:$false -ErrorAction Stop
                     }
                     else 
                     {
@@ -66,7 +66,7 @@ Process {
             }
 
             
-            It -name "$($VCServer.name) SMTP Server" -test {
+            It -name "$($VCServer) SMTP Server" -test {
                 $value = $VCMailSettings[3].value
                 try 
                 {
@@ -77,8 +77,8 @@ Process {
                     if ($Remediate) 
                     {
                         Write-Warning -Message $_
-                        Write-Warning -Message "Remediating SMTP Server on $($VCServer.name)"
-                        Get-AdvancedSetting -Entity $VCServer.name -Name mail.smtp.server | Set-AdvancedSetting -value $SMTPServer -Confirm:$false -ErrorAction Stop
+                        Write-Warning -Message "Remediating SMTP Server on $($VCServer)"
+                        Get-AdvancedSetting -Entity $VCServer -Name mail.smtp.server | Set-AdvancedSetting -value $SMTPServer -Confirm:$false -ErrorAction Stop
                     }
                     else 
                     {

--- a/Tests/Update-SMTP.Tests.ps1
+++ b/Tests/Update-SMTP.Tests.ps1
@@ -11,6 +11,7 @@ Param(
 
 Process {
     # Tests
+    Describe -Name 'vCenter Configuration: SMTP Settings' -Tags @("vcenter","SMTP") -Fixture {
         # Variables
         . $Config
         [string]$SMTPSender = $config.vcenter.smtpsender
@@ -20,6 +21,7 @@ Process {
         foreach ($VCServer in ($Global:DefaultVIServers)) 
         {
             It -name "$($VCServer.name) SMTP Sender" -test {
+                $value = Get-AdvancedSetting -Entity $VCServer.name -Name mail.sender | Select Value
                 try 
                 {
                     $value | Should Be $SMTPSender
@@ -30,6 +32,7 @@ Process {
                     {
                         Write-Warning -Message $_
                         Write-Warning -Message "Remediating SMTP Sender on $($VCServer.name)"
+                        Get-AdvancedSetting -Entity $VCServer.name -Name mail.sender | Set-AdvancedSetting -value $SMTPSender -Confirm:$false -ErrorAction Stop
                     }
                     else 
                     {
@@ -40,6 +43,7 @@ Process {
 
 
             It -name "$($VCServer.name) SMTP Port" -test {
+                $value = Get-AdvancedSetting -Entity $VCServer.name -Name mail.smtp.port | Select Value
                 try 
                 {
                     $value | Should Be $SMTPPort
@@ -50,6 +54,7 @@ Process {
                     {
                         Write-Warning -Message $_
                         Write-Warning -Message "Remediating SMTP Port on $($VCServer.name)"
+                        Get-AdvancedSetting -Entity $VCServer.name -Name mail.smtp.port | Set-AdvancedSetting -value $SMTPPort -Confirm:$false -ErrorAction Stop
                     }
                     else 
                     {
@@ -60,6 +65,7 @@ Process {
 
             
             It -name "$($VCServer.name) SMTP Server" -test {
+                $value = Get-AdvancedSetting -Entity $VCServer.name -Name mail.smtp.server | Select Value
                 try 
                 {
                     $value | Should Be $SMTPServer
@@ -70,6 +76,7 @@ Process {
                     {
                         Write-Warning -Message $_
                         Write-Warning -Message "Remediating SMTP Server on $($VCServer.name)"
+                        Get-AdvancedSetting -Entity $VCServer.name -Name mail.smtp.server | Set-AdvancedSetting -value $SMTPServer -Confirm:$false -ErrorAction Stop
                     }
                     else 
                     {

--- a/Tests/Update-SMTP.Tests.ps1
+++ b/Tests/Update-SMTP.Tests.ps1
@@ -20,8 +20,10 @@ Process {
 
         foreach ($VCServer in ($Global:DefaultVIServers)) 
         {
+        $VCMailSettings = Get-AdvancedSetting -Entity $VCServer.name -Name @('mail*')
+
             It -name "$($VCServer.name) SMTP Sender" -test {
-                $value = Get-AdvancedSetting -Entity $VCServer.name -Name mail.sender | Select Value
+                $value = $VCMailSettings[0].value
                 try 
                 {
                     $value | Should Be $SMTPSender
@@ -43,7 +45,7 @@ Process {
 
 
             It -name "$($VCServer.name) SMTP Port" -test {
-                $value = Get-AdvancedSetting -Entity $VCServer.name -Name mail.smtp.port | Select Value
+                $value = $VCMailSettings[2].value
                 try 
                 {
                     $value | Should Be $SMTPPort
@@ -65,7 +67,7 @@ Process {
 
             
             It -name "$($VCServer.name) SMTP Server" -test {
-                $value = Get-AdvancedSetting -Entity $VCServer.name -Name mail.smtp.server | Select Value
+                $value = $VCMailSettings[3].value
                 try 
                 {
                     $value | Should Be $SMTPServer
@@ -85,6 +87,6 @@ Process {
                 }
             }
 
-        }#End Foreach
+        }
     }
 }


### PR DESCRIPTION
Hi guys,

This is my first time dabbling with both Pester and GitHub, so hopefully I have done things correctly!

I've started small for my first contribution, which is to added a check and remediate (if required) the SMTP sender address, port and server for the vCenter Server.

I've tested this change against vCenter 6.

Any feedback is welcome!

Cheers, Matt.

- Created a new test, Update-SMTP.Tests.ps1. This will check and rediate (if required) the SMTP sender, port and mail server advanced properties for the vCenter Server.
- Line 23 in Config.Tests.ps1 has been modified to accept the additional properties as valid keys.
- Line 24 in Config.Tests.ps1 has been added to verify the key count on the config file
- Lines 26>28 in Config.Tests.ps1 have been added to validate the entry type within the config file.
- Lines 24>26 in Config.ps1 have been added, which are comments for the new config options used by the Update-SMTP function.
- Lines 31>33 in Config.ps1 have been added.