### PR TITLE
Vester module enhancement (Take 2)

### DIFF
--- a/Vester/Configs/Config.ps1
+++ b/Vester/Configs/Config.ps1
@@ -11,10 +11,11 @@
 #>
 
 $cfg.scope = @{
-    cluster = '*'
-    host    = '*'
-    vm      = '*'
-    vds     = '*'
+    datacenter = '*'
+    cluster    = '*'
+    host       = '*'
+    vm         = '*'
+    vds        = '*'
 
 }
 

--- a/Vester/Public/Invoke-Vester.ps1
+++ b/Vester/Public/Invoke-Vester.ps1
@@ -64,17 +64,17 @@ function Invoke-Vester {
                    ConfirmImpact = 'Medium')]
     # Passes -WhatIf through to other tests
     param (
+        # Optionally define a different config file to use
+        # Defaults to Vester\Configs\Config.ps1
+        [Parameter(ValueFromPipeline=$True,ValueFromPipelinebyPropertyName=$True)]
+        [ValidateScript({Foreach ($Path in $_) {Test-Path $Path -PathType 'Leaf'} })] 
+        [object[]]$Config = "$(Split-Path -Parent $PSScriptRoot)\Configs\Config.ps1",
+
         # Define the file/folder of test file(s) to call
         # Defaults to the current location
-        [Parameter(ValueFromPipelineByPropertyName = $true)]
         [Alias('Path','FullName')]
         [object[]]$Script = '.',
         # Aliasing FullName enables easy pipe from Get-ChildItem
-
-        # Optionally define a different config file to use
-        # Defaults to Vester\Configs\Config.ps1
-        [ValidateScript({Foreach ($Path in $_) {Test-Path $Path -PathType 'Leaf'} })] 
-        [object[]]$Config = "$(Split-Path -Parent $PSScriptRoot)\Configs\Config.ps1",
 
         # Optionally fix all config drift that is discovered
         # Defaults to false (disabled)
@@ -87,6 +87,7 @@ function Invoke-Vester {
 
     PROCESS {
         Foreach ($ConfigFile in $Config) {
+
             # Load the defined $cfg values to test
             Write-Verbose -Message "Processing Config file $ConfigFile"
             . $ConfigFile
@@ -109,7 +110,7 @@ function Invoke-Vester {
                 $VIServer = $global:DefaultVIServers | where-Object {$_.Name -match $cfg.vcenter.vc}
             }
             Write-Verbose "Processing against vCenter server '$($cfg.vcenter.vc)'"
-            # Need to ForEach if multiple -Script locations are not piped in
+            # Need to ForEach if multiple -Script locations
             ForEach ($Path in $Script) {
                 # Pester accepts Tag/Exclude being null, but each test will need $Config/$Remediate params
                 Invoke-Pester -Script @{

--- a/Vester/Public/Invoke-Vester.ps1
+++ b/Vester/Public/Invoke-Vester.ps1
@@ -100,11 +100,13 @@ function Invoke-Vester {
                 Try {
                     # Attempt connection to vCenter, prompting for credentials
                     Write-Verbose "No active connection found to configured vCenter '$($cfg.vcenter.vc)'. Connecting"
-                    Connect-VIServer -Server $cfg.vcenter.vc -Credential (Get-Credential) -ErrorAction Stop
+                    $VIServer = Connect-VIServer -Server $cfg.vcenter.vc -Credential (Get-Credential) -ErrorAction Stop
                 } Catch {
                     # If unable to connect, stop
                     throw "Unable to connect to configured vCenter '$($cfg.vcenter.vc)'. Exiting"
                 }
+            } else {
+                $VIServer = $global:DefaultVIServers | where-Object {$_.Name -match $cfg.vcenter.vc}
             }
             Write-Verbose "Processing against vCenter server '$($cfg.vcenter.vc)'"
             # Need to ForEach if multiple -Script locations are not piped in
@@ -113,7 +115,8 @@ function Invoke-Vester {
                 Invoke-Pester -Script @{
                     Path = $Path
                     Parameters = @{
-                        Config = $ConfigFile
+                        Cfg = $cfg
+                        VIServer = $VIServer
                         Remediate = $Remediate
                     }
                 } # Invoke-Pester

--- a/Vester/Tests/Cluster/Update-DRS.Tests.ps1
+++ b/Vester/Tests/Cluster/Update-DRS.Tests.ps1
@@ -7,18 +7,20 @@ Param(
     [switch]$Remediate = $false,
 
     # Optionally define a different config file to use. Defaults to Vester\Configs\Config.ps1
-    [string]$Config = (Split-Path $PSScriptRoot) + '\Configs\Config.ps1'
+    [Hashtable]$Cfg,
+
+    # VIserver Object
+    [VMware.VimAutomation.ViCore.Impl.V1.VIServerImpl]$VIServer
 )
 
 Process {
     # Tests
     Describe -Name 'Cluster Configuration: DRS Settings' -Tags @("vcenter","cluster") -Fixture {
         # Variables
-        . $Config
         [string]$drsmode = $cfg.cluster.drsmode
         [int]$drslevel = $cfg.cluster.drslevel
 
-        foreach ($cluster in (Get-Cluster -Name $cfg.scope.cluster)) 
+        foreach ($cluster in (Get-Datacenter -Name $cfg.scope.datacenter -Server $VIServer | Get-Cluster -Name $cfg.scope.cluster)) 
         {
             It -name "$($cluster.name) Cluster DRS Mode" -test {
                 $value = (Get-Cluster $cluster).DrsAutomationLevel

--- a/Vester/Tests/Cluster/Update-DRS.Tests.ps1
+++ b/Vester/Tests/Cluster/Update-DRS.Tests.ps1
@@ -6,7 +6,7 @@ Param(
     # Optionally fix all config drift that is discovered. Defaults to false (off)
     [switch]$Remediate = $false,
 
-    # Optionally define a different config file to use. Defaults to Vester\Configs\Config.ps1
+    # $Cfg hastable imported in Invoke-Vester
     [Hashtable]$Cfg,
 
     # VIserver Object

--- a/Vester/Tests/Host/Update-DNS.Tests.ps1
+++ b/Vester/Tests/Host/Update-DNS.Tests.ps1
@@ -7,7 +7,10 @@ Param(
     [switch]$Remediate = $false,
 
     # Optionally define a different config file to use. Defaults to Vester\Configs\Config.ps1
-    [string]$Config = (Split-Path $PSScriptRoot) + '\Configs\Config.ps1'
+    [Hashtable]$Cfg,
+
+    # VIserver Object
+    [VMware.VimAutomation.ViCore.Impl.V1.VIServerImpl]$VIServer
 )
 
 Process {
@@ -18,7 +21,7 @@ Process {
         [array]$esxdns = $cfg.host.esxdns
         [array]$searchdomains = $cfg.host.searchdomains
 
-        foreach ($server in (Get-VMHost -Name $cfg.scope.host)) 
+        foreach ($server in (Get-Datacenter -name $cfg.scope.datacenter -Server $VIServer | Get-Cluster -Name $cfg.scope.cluster | Get-VMHost -Name $cfg.scope.host)) 
         {
             It -name "$($server.name) Host DNS Address" -test {
                 [array]$value = (Get-VMHostNetwork -VMHost $server).DnsAddress

--- a/Vester/Tests/Host/Update-DNS.Tests.ps1
+++ b/Vester/Tests/Host/Update-DNS.Tests.ps1
@@ -6,7 +6,7 @@ Param(
     # Optionally fix all config drift that is discovered. Defaults to false (off)
     [switch]$Remediate = $false,
 
-    # Optionally define a different config file to use. Defaults to Vester\Configs\Config.ps1
+    # $Cfg hastable imported in Invoke-Vester
     [Hashtable]$Cfg,
 
     # VIserver Object
@@ -17,7 +17,6 @@ Process {
     # Tests
     Describe -Name 'Host Configuration: DNS Server(s)' -Tag @("host")-Fixture {
         # Variables
-        . $Config
         [array]$esxdns = $cfg.host.esxdns
         [array]$searchdomains = $cfg.host.searchdomains
 

--- a/Vester/Tests/Host/Update-NTP.Tests.ps1
+++ b/Vester/Tests/Host/Update-NTP.Tests.ps1
@@ -7,7 +7,10 @@ Param(
     [switch]$Remediate = $false,
 
     # Optionally define a different config file to use. Defaults to Vester\Configs\Config.ps1
-    [string]$Config = (Split-Path $PSScriptRoot) + '\Configs\Config.ps1'
+    [Hashtable]$Cfg,
+
+    # VIserver Object
+    [VMware.VimAutomation.ViCore.Impl.V1.VIServerImpl]$VIServer
 )
 
 Process {
@@ -17,7 +20,7 @@ Process {
         . $Config
         [array]$esxntp = $cfg.host.esxntp
 
-        foreach ($server in (Get-VMHost $cfg.scope.host)) 
+        foreach ($server in (Get-Datacenter -name $cfg.scope.datacenter -Server $VIServer | Get-Cluster -Name $cfg.scope.cluster | Get-VMHost -Name $cfg.scope.host)) 
         {
             It -name "$($server.name) Host NTP settings" -test {
                 $value = Get-VMHostNtpServer -VMHost $server

--- a/Vester/Tests/Host/Update-NTP.Tests.ps1
+++ b/Vester/Tests/Host/Update-NTP.Tests.ps1
@@ -6,7 +6,7 @@ Param(
     # Optionally fix all config drift that is discovered. Defaults to false (off)
     [switch]$Remediate = $false,
 
-    # Optionally define a different config file to use. Defaults to Vester\Configs\Config.ps1
+    # $Cfg hastable imported in Invoke-Vester
     [Hashtable]$Cfg,
 
     # VIserver Object
@@ -17,7 +17,6 @@ Process {
     # Tests
     Describe -Name 'Host Configuration: NTP Server(s)' -Tags @("host") -Fixture {
         # Variables
-        . $Config
         [array]$esxntp = $cfg.host.esxntp
 
         foreach ($server in (Get-Datacenter -name $cfg.scope.datacenter -Server $VIServer | Get-Cluster -Name $cfg.scope.cluster | Get-VMHost -Name $cfg.scope.host)) 

--- a/Vester/Tests/Host/Update-SSH.Tests.ps1
+++ b/Vester/Tests/Host/Update-SSH.Tests.ps1
@@ -6,7 +6,7 @@ Param(
     # Optionally fix all config drift that is discovered. Defaults to false (off)
     [switch]$Remediate = $false,
 
-    # Optionally define a different config file to use. Defaults to Vester\Configs\Config.ps1
+    # $Cfg hastable imported in Invoke-Vester
     [Hashtable]$Cfg,
 
     # VIserver Object
@@ -17,7 +17,6 @@ Process {
     # Tests
     Describe -Name 'Host Configuration: SSH Server' -Tags @("host")-Fixture {
         # Variables
-        . $Config
         [bool]$sshenable = $cfg.host.sshenable
         [int]$sshwarn = $cfg.host.sshwarn
 

--- a/Vester/Tests/Host/Update-SSH.Tests.ps1
+++ b/Vester/Tests/Host/Update-SSH.Tests.ps1
@@ -7,7 +7,10 @@ Param(
     [switch]$Remediate = $false,
 
     # Optionally define a different config file to use. Defaults to Vester\Configs\Config.ps1
-    [string]$Config = (Split-Path $PSScriptRoot) + '\Configs\Config.ps1'
+    [Hashtable]$Cfg,
+
+    # VIserver Object
+    [VMware.VimAutomation.ViCore.Impl.V1.VIServerImpl]$VIServer
 )
 
 Process {
@@ -18,7 +21,7 @@ Process {
         [bool]$sshenable = $cfg.host.sshenable
         [int]$sshwarn = $cfg.host.sshwarn
 
-        foreach ($server in (Get-VMHost -Name $cfg.scope.host)) 
+        foreach ($server in (Get-Datacenter -name $cfg.scope.datacenter -Server $VIServer | Get-Cluster -Name $cfg.scope.cluster | Get-VMHost -Name $cfg.scope.host)) 
         {
             It -name "$($server.name) Host SSH Service State" -test {
                 $value = $server |

--- a/Vester/Tests/Host/Update-Syslog.Tests.ps1
+++ b/Vester/Tests/Host/Update-Syslog.Tests.ps1
@@ -6,7 +6,7 @@ Param(
     # Optionally fix all config drift that is discovered. Defaults to false (off)
     [switch]$Remediate = $false,
 
-    # Optionally define a different config file to use. Defaults to Vester\Configs\Config.ps1
+    # $Cfg hastable imported in Invoke-Vester
     [Hashtable]$Cfg,
 
     # VIserver Object
@@ -17,7 +17,6 @@ Process {
     # Tests
     Describe -Name 'Host Configuration: Syslog Server' -Tags @("host") -Fixture {
         # Variables
-        . $Config
         [array]$esxsyslog = $cfg.host.esxsyslog
 
         foreach ($server in (Get-Datacenter -name $cfg.scope.datacenter -Server $VIServer | Get-Cluster -Name $cfg.scope.cluster | Get-VMHost -Name $cfg.scope.host)) 

--- a/Vester/Tests/Host/Update-Syslog.Tests.ps1
+++ b/Vester/Tests/Host/Update-Syslog.Tests.ps1
@@ -7,7 +7,10 @@ Param(
     [switch]$Remediate = $false,
 
     # Optionally define a different config file to use. Defaults to Vester\Configs\Config.ps1
-    [string]$Config = (Split-Path $PSScriptRoot) + '\Configs\Config.ps1'
+    [Hashtable]$Cfg,
+
+    # VIserver Object
+    [VMware.VimAutomation.ViCore.Impl.V1.VIServerImpl]$VIServer
 )
 
 Process {
@@ -17,7 +20,7 @@ Process {
         . $Config
         [array]$esxsyslog = $cfg.host.esxsyslog
 
-        foreach ($server in (Get-VMHost -Name $cfg.scope.host)) 
+        foreach ($server in (Get-Datacenter -name $cfg.scope.datacenter -Server $VIServer | Get-Cluster -Name $cfg.scope.cluster | Get-VMHost -Name $cfg.scope.host)) 
         {
             It -name "$($server.name) Host Syslog Service State" -test {
                 [array]$value = Get-VMHostSysLogServer -VMHost $server

--- a/Vester/Tests/Network/Update-VDS.Tests.ps1
+++ b/Vester/Tests/Network/Update-VDS.Tests.ps1
@@ -7,7 +7,10 @@ Param(
     [switch]$Remediate = $false,
 
     # Optionally define a different config file to use. Defaults to Vester\Configs\Config.ps1
-    [string]$Config = (Split-Path $PSScriptRoot) + '\Configs\Config.ps1'
+    [Hashtable]$Cfg,
+
+    # VIserver Object
+    [VMware.VimAutomation.ViCore.Impl.V1.VIServerImpl]$VIServer
 )
 
 Process {
@@ -19,7 +22,7 @@ Process {
         [string]$linkoperation = $cfg.vds.linkoperation
         [int]$mtu = $cfg.vds.mtu
 
-        foreach ($vds in (Get-VDSwitch -Name $cfg.scope.vds)) 
+        foreach ($vds in (Get-VDSwitch -Name $cfg.scope.vds -Server $VIServer)) 
         {
             It -name "$($vds.name) VDS Link Protocol" -test {
                 $value = $vds.LinkDiscoveryProtocol

--- a/Vester/Tests/Network/Update-VDS.Tests.ps1
+++ b/Vester/Tests/Network/Update-VDS.Tests.ps1
@@ -6,7 +6,7 @@ Param(
     # Optionally fix all config drift that is discovered. Defaults to false (off)
     [switch]$Remediate = $false,
 
-    # Optionally define a different config file to use. Defaults to Vester\Configs\Config.ps1
+    # $Cfg hastable imported in Invoke-Vester
     [Hashtable]$Cfg,
 
     # VIserver Object
@@ -17,7 +17,6 @@ Process {
     # Tests
     Describe -Name 'Network Configuration: VDS Settings' -Tags @('network','vds') -Fixture {
         # Variables
-        . $Config
         [string]$linkproto = $cfg.vds.linkproto
         [string]$linkoperation = $cfg.vds.linkoperation
         [int]$mtu = $cfg.vds.mtu

--- a/Vester/Tests/Storage/Update-NFS.Tests.ps1
+++ b/Vester/Tests/Storage/Update-NFS.Tests.ps1
@@ -6,7 +6,7 @@ Param(
     # Optionally fix all config drift that is discovered. Defaults to false (off)
     [switch]$Remediate = $false,
 
-    # Optionally define a different config file to use. Defaults to Vester\Configs\Config.ps1
+    # $Cfg hastable imported in Invoke-Vester
     [Hashtable]$Cfg,
 
     # VIserver Object
@@ -17,7 +17,6 @@ Process {
     # Tests
     Describe -Name 'Host Configuration: NFS Advanced Configuration' -Tag @("host","storage","nfs") -Fixture {
         # Variables
-        . $Config
         [Hashtable]$nfsadvconfig = $cfg.nfsadvconfig
         $compare = @()
         $nfsadvconfig.Values | ForEach-Object -Process {

--- a/Vester/Tests/Storage/Update-NFS.Tests.ps1
+++ b/Vester/Tests/Storage/Update-NFS.Tests.ps1
@@ -7,7 +7,10 @@ Param(
     [switch]$Remediate = $false,
 
     # Optionally define a different config file to use. Defaults to Vester\Configs\Config.ps1
-    [string]$Config = (Split-Path $PSScriptRoot) + '\Configs\Config.ps1'
+    [Hashtable]$Cfg,
+
+    # VIserver Object
+    [VMware.VimAutomation.ViCore.Impl.V1.VIServerImpl]$VIServer
 )
 
 Process {
@@ -15,12 +18,12 @@ Process {
     Describe -Name 'Host Configuration: NFS Advanced Configuration' -Tag @("host","storage","nfs") -Fixture {
         # Variables
         . $Config
-        [System.Collections.Hashtable]$nfsadvconfig = $cfg.nfsadvconfig
+        [Hashtable]$nfsadvconfig = $cfg.nfsadvconfig
         $compare = @()
         $nfsadvconfig.Values | ForEach-Object -Process {
             $compare += $_
         }
-        foreach ($server in (Get-VMHost -Name $cfg.scope.host).name) 
+        foreach ($server in (Get-Datacenter -name $cfg.scope.datacenter -Server $VIServer | Get-Cluster -Name $cfg.scope.cluster | Get-VMHost -Name $cfg.scope.host).name) 
         {
             $hostadvcfg = Get-AdvancedSetting -Entity $server
             $hostadvsettings = @{}

--- a/Vester/Tests/VM/Delete-Snapshot.Tests.ps1
+++ b/Vester/Tests/VM/Delete-Snapshot.Tests.ps1
@@ -7,7 +7,10 @@ Param(
     [switch]$Remediate = $false,
 
     # Optionally define a different config file to use. Defaults to Vester\Configs\Config.ps1
-    [string]$Config = (Split-Path $PSScriptRoot) + '\Configs\Config.ps1'
+    [Hashtable]$Cfg,
+
+    # VIserver Object
+    [VMware.VimAutomation.ViCore.Impl.V1.VIServerImpl]$VIServer
 )
 
 Process {
@@ -17,7 +20,7 @@ Process {
         . $Config
         [int]$snapretention = $cfg.vm.snapretention
 
-        foreach ($VM in (Get-VM -Name $cfg.scope.vm)) 
+        foreach ($VM in (Get-VM -Name $cfg.scope.vm -Server $VIServer)) 
         {
             It -name "$($VM.name) has no snapshot older than $snapretention day(s)" -test {
                 [array]$value = $VM |

--- a/Vester/Tests/VM/Delete-Snapshot.Tests.ps1
+++ b/Vester/Tests/VM/Delete-Snapshot.Tests.ps1
@@ -6,7 +6,7 @@ Param(
     # Optionally fix all config drift that is discovered. Defaults to false (off)
     [switch]$Remediate = $false,
 
-    # Optionally define a different config file to use. Defaults to Vester\Configs\Config.ps1
+    # $Cfg hastable imported in Invoke-Vester
     [Hashtable]$Cfg,
 
     # VIserver Object
@@ -17,10 +17,9 @@ Process {
     # Tests
     Describe -Name 'VM Configuration: Snapshot(s)' -Tag @("vm") -Fixture {
         # Variables
-        . $Config
         [int]$snapretention = $cfg.vm.snapretention
 
-        foreach ($VM in (Get-VM -Name $cfg.scope.vm -Server $VIServer)) 
+        foreach ($VM in (Get-Datacenter -name $cfg.scope.datacenter -Server $VIServer | Get-Cluster -Name $cfg.scope.cluster | Get-VMHost -Name $cfg.scope.host | Get-VM -Name $cfg.scope.vm)) 
         {
             It -name "$($VM.name) has no snapshot older than $snapretention day(s)" -test {
                 [array]$value = $VM |

--- a/Vester/Tests/VM/Disable-Limit.Tests.ps1
+++ b/Vester/Tests/VM/Disable-Limit.Tests.ps1
@@ -6,7 +6,7 @@ Param(
     # Optionally fix all config drift that is discovered. Defaults to false (off)
     [switch]$Remediate = $false,
 
-    # Optionally define a different config file to use. Defaults to Vester\Configs\Config.ps1
+    # $Cfg hastable imported in Invoke-Vester
     [Hashtable]$Cfg,
 
     # VIserver Object
@@ -18,11 +18,10 @@ Process {
     # CPU Limits 
     Describe -Name 'VM Configuration: CPU Limit' -Tags @("vm") -Fixture {
         # Variables
-        . $Config
         [bool]$allowcpulimit    = $cfg.vm.allowcpulimit
 
         If (-not $allowcpulimit) {
-            foreach ($VM in (Get-VM -Name $cfg.scope.vm -Server $VIServer)) 
+            foreach ($VM in (Get-Datacenter -name $cfg.scope.datacenter -Server $VIServer | Get-Cluster -Name $cfg.scope.cluster | Get-VMHost -Name $cfg.scope.host | Get-VM -Name $cfg.scope.vm)) 
             {
                 It -name "$($VM.name) has no CPU limits configured" -test {
                     [array]$value = $VM | Get-VMResourceConfiguration
@@ -59,7 +58,7 @@ Process {
         [bool]$allowmemorylimit = $cfg.vm.allowmemorylimit
 
         If (-not $allowmemorylimit) {
-            foreach ($VM in (Get-VM -Name $cfg.scope.vm -Server $VIServer)) 
+            foreach ($VM in (Get-Datacenter -name $cfg.scope.datacenter -Server $VIServer | Get-Cluster -Name $cfg.scope.cluster | Get-VMHost -Name $cfg.scope.host | Get-VM -Name $cfg.scope.vm)) 
             {
                 It -name "$($VM.name) has no memory limits configured" -test {
                     [array]$value = $VM | Get-VMResourceConfiguration

--- a/Vester/Tests/VM/Disable-Limit.Tests.ps1
+++ b/Vester/Tests/VM/Disable-Limit.Tests.ps1
@@ -7,7 +7,10 @@ Param(
     [switch]$Remediate = $false,
 
     # Optionally define a different config file to use. Defaults to Vester\Configs\Config.ps1
-    [string]$Config = (Split-Path $PSScriptRoot) + '\Configs\Config.ps1'
+    [Hashtable]$Cfg,
+
+    # VIserver Object
+    [VMware.VimAutomation.ViCore.Impl.V1.VIServerImpl]$VIServer
 )
 
 Process {
@@ -19,7 +22,7 @@ Process {
         [bool]$allowcpulimit    = $cfg.vm.allowcpulimit
 
         If (-not $allowcpulimit) {
-            foreach ($VM in (Get-VM -Name $cfg.scope.vm)) 
+            foreach ($VM in (Get-VM -Name $cfg.scope.vm -Server $VIServer)) 
             {
                 It -name "$($VM.name) has no CPU limits configured" -test {
                     [array]$value = $VM | Get-VMResourceConfiguration
@@ -56,7 +59,7 @@ Process {
         [bool]$allowmemorylimit = $cfg.vm.allowmemorylimit
 
         If (-not $allowmemorylimit) {
-            foreach ($VM in (Get-VM -Name $cfg.scope.vm)) 
+            foreach ($VM in (Get-VM -Name $cfg.scope.vm -Server $VIServer)) 
             {
                 It -name "$($VM.name) has no memory limits configured" -test {
                     [array]$value = $VM | Get-VMResourceConfiguration

--- a/Vester/Tests/VM/Disconnect-CDROM.Tests.ps1
+++ b/Vester/Tests/VM/Disconnect-CDROM.Tests.ps1
@@ -6,7 +6,7 @@ Param(
     # Optionally fix all config drift that is discovered. Defaults to false (off)
     [switch]$Remediate = $false,
 
-    # Optionally define a different config file to use. Defaults to Vester\Configs\Config.ps1
+    # $Cfg hastable imported in Invoke-Vester
     [Hashtable]$Cfg,
 
     # VIserver Object
@@ -17,11 +17,10 @@ Process {
     # Tests
     Describe -Name 'VM Configuration: CDROM status' -Tag @("vm") -Fixture {
         # Variables
-        . $Config
         [bool]$allowconnectedcdrom = $cfg.vm.allowconnectedcdrom
 
         If (-not $allowconnectedcdrom) {
-            foreach ($VM in (Get-VM -Name $cfg.scope.vm -Server $VIServer)) 
+            foreach ($VM in (Get-Datacenter -name $cfg.scope.datacenter -Server $VIServer | Get-Cluster -Name $cfg.scope.cluster | Get-VMHost -Name $cfg.scope.host | Get-VM -Name $cfg.scope.vm)) 
             {
                 [array]$value = $VM | get-cddrive
                 It -name "$($VM.name) has no CDROM connected to ISO file " -test {

--- a/Vester/Tests/VM/Disconnect-CDROM.Tests.ps1
+++ b/Vester/Tests/VM/Disconnect-CDROM.Tests.ps1
@@ -7,7 +7,10 @@ Param(
     [switch]$Remediate = $false,
 
     # Optionally define a different config file to use. Defaults to Vester\Configs\Config.ps1
-    [string]$Config = (Split-Path $PSScriptRoot) + '\Configs\Config.ps1'
+    [Hashtable]$Cfg,
+
+    # VIserver Object
+    [VMware.VimAutomation.ViCore.Impl.V1.VIServerImpl]$VIServer
 )
 
 Process {
@@ -18,7 +21,7 @@ Process {
         [bool]$allowconnectedcdrom = $cfg.vm.allowconnectedcdrom
 
         If (-not $allowconnectedcdrom) {
-            foreach ($VM in (Get-VM -Name $cfg.scope.vm)) 
+            foreach ($VM in (Get-VM -Name $cfg.scope.vm -Server $VIServer)) 
             {
                 [array]$value = $VM | get-cddrive
                 It -name "$($VM.name) has no CDROM connected to ISO file " -test {


### PR DESCRIPTION
This PR change some behavior and add functionalities to `Invoke-Vester`:

- Add the possibility to accept config files from the pipeline
```Powershell
'.\Config_1.ps1','.\Config_2.ps1' | Invoke-Vester
```
- Remove the possibility to accept scripts from the pipeline
- Import config file only in `Invoke-Vester` and pass it to tests as a parameter
- Pass VIServerImpl object to all tests as a paramter. This object is used to replace $cfg.vcenter.vc
- Add the `datacenter` scope



Feel free to comment / review !

