### PR TITLE
Fix issue when remediating cdrom configuration

### DIFF
--- a/Vester/Tests/VM/CDDrive-Host.Vester.ps1
+++ b/Vester/Tests/VM/CDDrive-Host.Vester.ps1
@@ -18,7 +18,7 @@ $Title = 'CD-ROM Host Device'
 # Use $Object to help filter, and $Desired to set the correct value
 [ScriptBlock]$Fix = {
     If ($Desired -eq $false) {
-        $Object | Set-CDDrive -NoMedia -Confirm:$false
+        $Object | Get-CDDrive | Set-CDDrive -NoMedia -Confirm:$false
     } Else {
         Write-Warning 'CD-ROM tests do not remediate against a desired value of $true'
     }

--- a/Vester/Tests/VM/CDDrive-ISO.Vester.ps1
+++ b/Vester/Tests/VM/CDDrive-ISO.Vester.ps1
@@ -18,7 +18,7 @@ $Title = 'CD-ROM ISO File'
 # Use $Object to help filter, and $Desired to set the correct value
 [ScriptBlock]$Fix = {
     If ($Desired -eq $false) {
-        $Object | Set-CDDrive -NoMedia -Confirm:$false
+        $Object | Get-CDDrive | Set-CDDrive -NoMedia -Confirm:$false
     } Else {
         Write-Warning 'CD-ROM tests do not remediate against a desired value of $true'
     }


### PR DESCRIPTION
Everything is in the title...

```Get-CDDrive``` was missing in the $fix scriptblock

```Powershell
[ScriptBlock]$Fix = {
    If ($Desired -eq $false) {
        $Object | Get-CDDrive | Set-CDDrive -NoMedia -Confirm:$false
    } Else {
        Write-Warning 'CD-ROM tests do not remediate against a desired value of $true'
    }
}
```