### PR TITLE
Add pester tests for public functions parameters

### DIFF
--- a/Tests/Function/Function.Data.ps1
+++ b/Tests/Function/Function.Data.ps1
@@ -1,0 +1,25 @@
+$Data = @{}
+
+$Data.function1 = @{
+    Name = 'Invoke-Vester'
+    Parameters = @(
+        @{'Name' = 'Config'; 'type' = 'object[]'; 'Mandatory' = $False; 'ValueFromPipeline' = $True; 'ValueFromPipelinebyPropertyName' = $True; 'Aliases' = @('FullName')},
+        @{'Name' = 'Test'; 'type' = 'object[]'; 'Mandatory' = $False; 'ValueFromPipeline' = $False; 'ValueFromPipelinebyPropertyName' = $False; 'Aliases' = @('Path','Script')},
+        @{'Name' = 'Remediate'; 'type' = 'SwitchParameter'; 'Mandatory' = $False; 'ValueFromPipeline' = $False; 'ValueFromPipelinebyPropertyName' = $False},
+        @{'Name' = 'XMLOutputFile'; 'type' = 'object'; 'Mandatory' = $False; 'ValueFromPipeline' = $False; 'ValueFromPipelinebyPropertyName' = $False}
+    )
+}
+
+$Data.function2 = @{
+    Name = 'New-VesterConfig'
+    Parameters = @(
+        @{'Name' = 'OutputFolder'; 'type' = 'object'; 'Mandatory' = $False; 'ValueFromPipeline' = $False; 'ValueFromPipelinebyPropertyName' = $False},
+        @{'Name' = 'Quiet'; 'type' = 'SwitchParameter'; 'Mandatory' = $False; 'ValueFromPipeline' = $False; 'ValueFromPipelinebyPropertyName' = $False}
+    )
+}
+
+
+
+
+
+

--- a/Tests/Function/Function.Tests.ps1
+++ b/Tests/Function/Function.Tests.ps1
@@ -1,0 +1,80 @@
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+#Get information from the module manifest
+$manifestPath = "$here\..\..\Vester\Vester.psd1"
+$manifest = Test-ModuleManifest -Path $manifestPath
+
+#Test if a Vester module is already loaded
+$Module = Get-Module -Name 'Vester' -ErrorAction SilentlyContinue
+
+#Load the module if needed (not already loaded or not the good version)
+If ($Module) {
+    If ($Module.Version -ne $manifest.version) {
+        Remove-Module $Module
+        $Module = Import-Module "$here\..\..\Vester" -Version $manifest.version -force
+    }
+} else {
+    $Module = Import-Module "$here\..\..\Vester" -Version $manifest.version -force
+}
+
+# Load the datas
+. $here\Function.Data.ps1
+
+
+# Pester tests
+Describe "No public function left behind" {
+
+    $Module.ExportedFunctions.GetEnumerator() | ForEach-Object {
+        $Name = $_.Value.Name
+
+        It "Function $Name is tested" {
+            $data.values.name -contains $Name | Should Be $True
+        }
+    }
+}
+
+Describe "Functions Parameters" {
+
+    $Data.GetEnumerator() | ForEach-Object {
+
+        $Name = $_.Value.Name
+        $Params = $_.Value.Parameters
+
+        Context "$Name" {
+            $Command = Get-Command -Name $Name
+
+            Foreach ($Param in $Params) {
+
+                It "Function $($command.Name) contains Parameter $($Param['Name'])" {
+                    $Command.Parameters.Keys -contains $Param['Name'] | Should Be $True
+                }
+
+                It "Parameter $($Param['Name']) type is $($Param['type'])" {
+                    $Command.Parameters.($Param['Name']).ParameterType.Name -eq $Param['Type'] | Should Be $True
+                }
+
+                It "Parameter $($Param['Name']) Mandatory value is $($Param['mandatory'])" {
+                    $Command.Parameters.($Param['Name']).Attributes.Mandatory | Should Be $Param['mandatory']
+                }
+
+                It "Parameter $($Param['Name']) ValueFromPipeline value is $($Param['ValueFromPipeline'])" {
+                    $Command.Parameters.($Param['Name']).Attributes.ValueFromPipeline | Should Be $Param['ValueFromPipeline']
+                }
+
+                It "Parameter $($Param['Name']) ValueFromPipeline value is $($Param['ValueFromPipelineByPropertyName'])" {
+                    $Command.Parameters.($Param['Name']).Attributes.ValueFromPipelineByPropertyName | Should Be $Param['ValueFromPipelineByPropertyName']
+                }
+
+                If ($Param['Aliases']) {
+                    It "Parameter $($Param['Name']) Aliases are $($Param['Aliases'])" {
+                        Compare-Object -ReferenceObject $Param['Aliases'] -DifferenceObject $Command.Parameters.($Param['Name']).Aliases | Should BeNullOrEmpty
+                    }
+                } else {
+                    It "Parameter $($Param['Name']) has no aliase" {
+                        $Command.Parameters.($Param['Name']).Aliases | Should BeNullOrEmpty
+                    }                      
+                }                 
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pester tests checks public functions parameters.

It reads a definition of the function's parameter in a file named `Function.Data.ps1`. each function has to be declared in that file as long as the function's parameters.

Example of a function declaration:

```Powershell
$Data = @{}

$Data.function1 = @{
    Name = 'Invoke-Vester'
    Parameters = @(
        @{'Name' = 'Config'; 'type' = 'object[]'; 'Mandatory' = $False; 'ValueFromPipeline' = $True; 'ValueFromPipelinebyPropertyName' = $True; 'Aliases' = @('FullName')},
        @{'Name' = 'Test'; 'type' = 'object[]'; 'Mandatory' = $False; 'ValueFromPipeline' = $False; 'ValueFromPipelinebyPropertyName' = $False; 'Aliases' = @('Path','Script')},
        @{'Name' = 'Remediate'; 'type' = 'SwitchParameter'; 'Mandatory' = $False; 'ValueFromPipeline' = $False; 'ValueFromPipelinebyPropertyName' = $False},
        @{'Name' = 'XMLOutputFile'; 'type' = 'object'; 'Mandatory' = $False; 'ValueFromPipeline' = $False; 'ValueFromPipelinebyPropertyName' = $False}
    )
}
```

The pester's tests in `Function.Tests.ps1` will check if there's any drift between the function and it's "desired configuration".

Output of a successfull test:


```
> Invoke-Pester .\Tests\Function\

Describing No public function left behind
 [+] Function Invoke-Vester is tested 663ms
 [+] Function New-VesterConfig is tested 20ms
Describing Functions Parameters
   Context Invoke-Vester
    [+] Function Invoke-Vester contains Parameter Config 355ms
    [+] Parameter Config type is object[] 17ms
    [+] Parameter Config Mandatory value is False 18ms
    [+] Parameter Config ValueFromPipeline value is True 18ms
    [+] Parameter Config ValueFromPipeline value is True 33ms
    [+] Parameter Config Aliases are FullName 16ms
    [+] Function Invoke-Vester contains Parameter Test 15ms
    [+] Parameter Test type is object[] 15ms
    [+] Parameter Test Mandatory value is False 16ms
    [+] Parameter Test ValueFromPipeline value is False 15ms
    [+] Parameter Test ValueFromPipeline value is False 21ms
    [+] Parameter Test Aliases are Path Script 15ms
    [+] Function Invoke-Vester contains Parameter Remediate 12ms
    [+] Parameter Remediate type is SwitchParameter 14ms
    [+] Parameter Remediate Mandatory value is False 16ms
    [+] Parameter Remediate ValueFromPipeline value is False 16ms
    [+] Parameter Remediate ValueFromPipeline value is False 16ms
    [+] Parameter Remediate has no aliase 17ms
    [+] Function Invoke-Vester contains Parameter XMLOutputFile 16ms
    [+] Parameter XMLOutputFile type is object 18ms
    [+] Parameter XMLOutputFile Mandatory value is False 19ms
    [+] Parameter XMLOutputFile ValueFromPipeline value is False 16ms
    [+] Parameter XMLOutputFile ValueFromPipeline value is False 16ms
    [+] Parameter XMLOutputFile has no aliase 15ms
   Context New-VesterConfig
    [+] Function New-VesterConfig contains Parameter OutputFolder 302ms
    [+] Parameter OutputFolder type is object 12ms
    [+] Parameter OutputFolder Mandatory value is False 14ms
    [+] Parameter OutputFolder ValueFromPipeline value is False 16ms
    [+] Parameter OutputFolder ValueFromPipeline value is False 18ms
    [+] Parameter OutputFolder has no aliase 16ms
    [+] Function New-VesterConfig contains Parameter Quiet 16ms
    [+] Parameter Quiet type is SwitchParameter 17ms
    [+] Parameter Quiet Mandatory value is False 18ms
    [+] Parameter Quiet ValueFromPipeline value is False 20ms
    [+] Parameter Quiet ValueFromPipeline value is False 16ms
    [+] Parameter Quiet has no aliase 15ms
```


