### PR TITLE
Improve unit test suite

### DIFF
--- a/Tests/Module/TestFiles.Tests.ps1
+++ b/Tests/Module/TestFiles.Tests.ps1
@@ -1,0 +1,62 @@
+﻿# Check each .Vester.ps1 test against general assumptions
+
+Describe 'Unit Tests' -Tag 'unit' {
+    $TestFiles = Get-ChildItem "$PSScriptRoot\..\..\Vester\Tests" -File -Recurse
+    $cfg = @{}
+        
+    ForEach ($Test in $TestFiles) {
+        # Use RegEx to help capture the line that defines the test's $cfg.abc.xyz value
+        $CfgLine = ($Test | Select-String '\$cfg') -replace '.*\:[0-9]+\:',''
+        $CfgLine.Count | Should Be 1
+
+        # Use RegEx and matching to look for a type declaration
+        If ($CfgLine -match '\[([a-z]+)\].*\$cfg\.([a-z]+)\.([a-z]+)$') {
+            # $Desired is strongly typed ([int] | [bool] | [string])
+            $Type = $Matches[1]
+        } ElseIf ($CfgLine -match '\$(cfg)\.([a-z]+)\.([a-z]+)$') {
+            # $Desired is not strongly typed, which we do when allowing arrays
+            $Type = 'object'
+        } Else {
+            throw "Unable to match `$Desired line of test file $($Test.BaseName)"
+        }
+
+        # For the $Type discovered, set a dummy value of that type
+        $CfgValue = switch ($Type) {
+            'bool'   {$true}
+            'int'    {1}
+            'string' {'test'}
+            'object' {@('1','2')}
+        }
+
+        # Still using the -match results, set this test's $cfg.abc.xyz
+        $cfg.($Matches[2]) = @{$Matches[3] = $CfgValue}
+
+        # Dot sourcing loads the four expected variables
+        . $Test.FullName
+
+        It "$(Split-Path $Test.FullName -Leaf) loads expected variables" {
+            $Title   | Should Not BeNullOrEmpty
+            $Desired | Should Not BeNullOrEmpty
+            $Actual  | Should Not BeNullOrEmpty
+            $Fix     | Should Not BeNullOrEmpty
+        }
+
+        It "$(Split-Path $Test.FullName -Leaf) variables have proper types" {
+            $Title   | Should BeOfType String
+            $Desired | Should BeOfType $Type
+            $Actual  | Should BeOfType ScriptBlock
+            $Fix     | Should BeOfType ScriptBlock
+        }
+
+        It "$(Split-Path $Test.FullName -Leaf) is properly scoped" {
+            $Actual | Should BeLike '*$Object*'
+            $Fix | Should BeLike '*$Object*'
+            $Fix | Should BeLike '*$Desired*'
+        }
+
+        # Completely remove the loaded variables for the next test
+        @('Title','Desired','Actual','Fix') | ForEach-Object {
+            Remove-Variable -Name $_
+        }
+    } #ForEach $Test
+} #Describe

--- a/Tests/Module/Vester.Tests.ps1
+++ b/Tests/Module/Vester.Tests.ps1
@@ -1,25 +1,71 @@
-$manifestPath = "$PSScriptRoot\..\..\Vester\Vester.psd1"
+# Test Vester .psd1, .psm1, general module structure, and function availability
 
-Import-Module "$PSScriptRoot\..\..\Vester" -force
+Get-Module Vester | Remove-Module -Force
+Import-Module "$PSScriptRoot\..\..\Vester" -Force
 
-Describe -Tags 'VersionChecks' "Vester manifest" {
-    $manifest = Test-ModuleManifest -Path $manifestPath -ErrorAction Stop
+Describe 'Check module files for breaking changes' {
+    $ModuleRoot = "$PSScriptRoot\..\..\Vester"
+    $PublicFiles = (Get-ChildItem "$ModuleRoot\Public").BaseName
 
-    It "has a valid manifest" {
-        {
-            $manifest = Test-ModuleManifest -Path $manifestPath -ErrorAction Stop -WarningAction SilentlyContinue
-        } | Should Not Throw
+    It 'Contains expected helper files and directories' {
+        "$ModuleRoot\Configs\readme.txt" | Should Exist
+        "$ModuleRoot\en-US\about_Vester.help.txt" | Should Exist
+        "$ModuleRoot\Private\Template\VesterTemplate.Tests.ps1" | Should Exist
+        "$ModuleRoot\Public" | Should Exist
+        "$ModuleRoot\Tests" | Should Exist
+        "$ModuleRoot\..\LICENSE" | Should Exist
+        "$ModuleRoot\..\README.md" | Should Exist
     }
 
-    It "has a valid name in the manifest" {
-        $manifest.Name | Should Be 'Vester'
+    Context 'Verify .psd1 module file' {
+        It 'Has a valid .psd1 module manifest' {
+            {Test-ModuleManifest -Path "$ModuleRoot\Vester.psd1" -ErrorAction Stop -WarningAction SilentlyContinue} | Should Not Throw
+        }
+
+        $manifest = Test-ModuleManifest -Path "$ModuleRoot\Vester.psd1" -ErrorAction Stop
+
+        It 'Static .psd1 values have not changed' {
+            $manifest.RootModule | Should BeExactly 'Vester.psm1'
+            $manifest.Name | Should BeExactly 'Vester'
+            $manifest.Version -as [Version] | Should BeGreaterThan '1.0.0'
+            $manifest.Guid | Should BeExactly 'cd038486-b669-4edb-a66d-bfe94c61b011'
+            $manifest.Author | Should BeExactly 'Chris Wahl'
+            $manifest.CompanyName | Should BeExactly 'Community'
+            $manifest.Copyright | Should BeExactly 'Apache License'
+            $manifest.Description | Should BeOfType String
+            $manifest.PowerShellVersion | Should Be '3.0'
+            # TODO: Need to rewrite this? Issue #74
+            $manifest.RequiredModules | Should BeExactly 'Pester'
+            $manifest.ExportedFunctions.Values.Name | Should BeExactly $PublicFiles
+
+            $manifest.PrivateData.PSData.Tags | Should BeExactly @('vester','vmware','vcenter','vsphere','esxi','powercli')
+            $manifest.PrivateData.PSData.LicenseUri | Should BeExactly 'https://github.com/WahlNetwork/Vester/blob/master/LICENSE'
+            $manifest.PrivateData.PSData.ProjectUri | Should BeExactly 'https://github.com/WahlNetwork/Vester'
+            # TODO: .ExternalModuleDependencies ?
+        }
+
+        It 'Exports all functions within the Public folder' {
+            (Get-Command -Module Vester).Name | Should BeExactly $PublicFiles
+        }
     }
 
-    It "has a valid guid in the manifest" {
-        $manifest.Guid | Should Be 'cd038486-b669-4edb-a66d-bfe94c61b011'
-    }
+    # InModuleScope helps test private functions
+    InModuleScope Vester {
+        # Run unit tests for all private functions here
+        # Instead of breaking out into individual files like the public functions
+        Context 'Contains expected private functions' {
+            It 'Read-HostColor behaves normally' {
+                Mock Write-Host {} -Verifiable
+                Mock Read-Host {return 'rh-Test'} -Verifiable
 
-    It "has a valid version in the manifest" {
-        $manifest.Version -as [Version] | Should Not BeNullOrEmpty
-    }
-}
+                Read-HostColor | Should BeExactly 'rh-Test'
+
+                # Ensure that Write-Host & Read-Host were actually called within Read-HostColor
+                Assert-MockCalled Write-Host
+                Assert-MockCalled Read-Host
+            }
+
+            # (Any additional private functions as It tests here)
+        } #Context private
+    } #InModuleScope
+} #Describe

--- a/Vester/Public/New-VesterConfig.ps1
+++ b/Vester/Public/New-VesterConfig.ps1
@@ -2,7 +2,51 @@
 
 function New-VesterConfig {
     <#
-    TODO: Comment-based help
+    .SYNOPSIS
+    Generates a Vester config file from settings in your existing VMware environment.
+
+    .DESCRIPTION
+    New-VesterConfig is designed to be a quick way to get started with Vester.
+
+    Vester needs one config file for each vCenter server it interacts with. To
+    help speed up this one-time creation process, New-VesterConfig uses PowerCLI
+    to pull current values from your environment to store in the config file.
+    
+    You'll be prompted with the list of Clusters/Hosts/VMs/etc. discovered, and
+    asked to choose one of each type to use as a baseline; i.e. "all my other
+    hosts should be configured like this one." Those values are displayed
+    interactively, and you can edit them as desired.
+
+    Optionally, advanced users can use the -Quiet parameter. This suppresses
+    all host output and prompts. Instead, values are pulled from the first
+    Cluster/Host/VM/etc. found alphabetically. Manual review afterward of the
+    config file is strongly encouraged if using the -Quiet parameter.
+
+    It outputs a single Config.json file at \Vester\Configs, which may require
+    admin rights. Optionally, you can use the -OutputFolder parameter to
+    specify a different folder to store the Config.json file.
+
+    .EXAMPLE
+    New-VesterConfig
+    Ensures that you are connected to only one vCenter server.
+    Discovers values from your environment and displays them, occasionally
+    prompting for a selection of which cluster/host/etc. to use.
+    Outputs a new Vester config file to '\Vester\Configs\Config.json',
+    which may require admin rights.
+
+    .EXAMPLE
+    New-VesterConfig -Quiet -OutputFolder "$env:USERPROFILE\Desktop"
+    -Quiet suppresses all host output and prompts, instead pulling values
+    from the first cluster/host/etc. found alphabetically.
+    Upon completion, Config.json will be created on your Desktop.
+
+    .NOTES
+    This command relies on the Pester and PowerCLI modules for testing.
+
+    "Get-Help about_Vester" for more information.
+
+    .LINK
+    https://github.com/WahlNetwork/Vester
     #>
     [CmdletBinding()]
     param (
@@ -417,8 +461,8 @@ function New-VesterConfig {
 
     # Set the section's config, and then display it for review
     $config.vds = [ordered]@{
-            linkproto     = $vds.LinkDiscoveryProtocol
-            linkoperation = $vds.LinkDiscoveryProtocolOperation
+            linkproto     = "$($vds.LinkDiscoveryProtocol)"
+            linkoperation = "$($vds.LinkDiscoveryProtocolOperation)"
             mtu           = $vds.Mtu
     }
 


### PR DESCRIPTION
Addresses #69 and supplements #76.

Exhaustive testing of the .psd1 file to alert on unexpected changes. Recursively testing .Vester.ps1 test files to ensure they will properly interact with `Invoke-Vester`.

`Invoke-Pester .\Vester\Tests`

Expected failures:

- `Get-VdsCommand` (and potentially other PowerCLI crap)
    - See open issue #74
- `Expected {1.0.0} to be greater than {1.0.0}`
    - Increment the module version 😉

I haven't really reviewed @equelin's public function unit tests yet. I'll probably add to those tests in a different PR, as I'm not sure how quickly I'll get to that.