### PR TITLE
adding ntp-service.vester.ps1 to test ntpd service

### DIFF
--- a/Vester/Tests/Host/NTP-Service.Vester.ps1
+++ b/Vester/Tests/Host/NTP-Service.Vester.ps1
@@ -1,0 +1,43 @@
+# Test file for the Vester module - https://github.com/WahlNetwork/Vester
+# Called via Invoke-Pester VesterTemplate.Tests.ps1
+
+# Test title, e.g. 'DNS Servers'
+$Title = 'NTP Service State'
+
+# Test description: How New-VesterConfig explains this value to the user
+$Description = 'Checks state of NTP service (running or stopped)'
+
+# The config entry stating the desired values
+$Desired = $cfg.host.ntpservicerunning
+
+# The test value's data type, to help with conversion: bool/string/int
+$Type = 'bool'
+
+# The command(s) to pull the actual value for comparison
+# $Object will scope to the folder this test is in (Cluster, Host, etc.)
+[ScriptBlock]$Actual = {
+    ($Object | Get-VMHostService | Where-Object -FilterScript {
+        $_.Key -eq 'ntpd'
+    }).Running
+}
+
+# The command(s) to match the environment to the config
+# Use $Object to help filter, and $Desired to set the correct value
+[ScriptBlock]$Fix = {
+    if ($Desired -eq $true) 
+    {
+        Start-VMHostService -HostService ($Object |
+            Get-VMHostService |
+            Where-Object -FilterScript {
+                $_.Key -eq 'ntpd'
+        }) -ErrorAction Stop -Confirm:$false
+    }
+    if ($Desired -eq $false) 
+    {
+        Stop-VMHostService -HostService ($Object |
+            Get-VMHostService |
+            Where-Object -FilterScript {
+                $_.Key -eq 'ntpd'
+        }) -ErrorAction Stop -Confirm:$false
+    }
+}


### PR DESCRIPTION
Simple ntp service Vest to test ntp daemon "Running" state and set to desired state if -Remediate is passed.  Ran -Remediate in both directions with success.