### PR TITLE
Issue# 114 - VesterTemplate.Tests.ps1 Performance Updates

### DIFF
--- a/Vester/Private/Template/VesterTemplate.Tests.ps1
+++ b/Vester/Private/Template/VesterTemplate.Tests.ps1
@@ -132,6 +132,6 @@ foreach($Scope in $Final.Scope)
                     } #Try/Catch
                 } #It
             } #Describe                    
-        }#Foreach Testfiles
-    }#Foreach $Final.InventoryList
-}#Foreach Scopes
+        }#Foreach Inventory
+    }#Foreach Tests
+}#Foreach Final.Scope

--- a/Vester/Private/Template/VesterTemplate.Tests.ps1
+++ b/Vester/Private/Template/VesterTemplate.Tests.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 This file exists to combine simple user input (Invoke-Vester), simple
 user test authoring (*.Vester.ps1), and properly scoped inventory objects
 into a single test session that loops through all necessary combinations.
@@ -88,13 +88,13 @@ foreach($Scope in $Final.Scope)
     # Runs through each test file on the below objects in the current scope
     foreach($Test in $Tests)
     {
+        Write-Verbose "Processing test file $Test"
+        $TestName = Split-Path $Test -Leaf
 
         # Loops through each object in the inventory list for the specific scope.
         # It runs one test at a time against each $Object and moves onto the next test.
         foreach($Object in $Inventory)
         {
-            Write-Verbose "Processing test file $Test"
-            $TestName = Split-Path $Test -Leaf
 
             Describe -Name "$Scope Configuration: $TestName" -Fixture {
                 # Pull in $Title/$Description/$Desired/$Type/$Actual/$Fix from the test file

--- a/Vester/Private/Template/VesterTemplate.Tests.ps1
+++ b/Vester/Private/Template/VesterTemplate.Tests.ps1
@@ -83,13 +83,7 @@ foreach($Scope in $Final.Scope)
             # Use continue to skip this test and go to the next loop iteration
             continue
         }
-    }
-
-    If (($Final | Where-Object { $_.Scope -eq $Scope }).InventoryList -eq $null) {
-        Write-Verbose "No objects found in scope $Scope, skipping tests"
-        # Use continue to skip this test and go to the next loop iteration
-        continue
-    }    
+    }  
 
     # Loops through each object in the inventory list for the specific scope
     foreach($Object in $Inventory)

--- a/Vester/Private/Template/VesterTemplate.Tests.ps1
+++ b/Vester/Private/Template/VesterTemplate.Tests.ps1
@@ -65,7 +65,7 @@ foreach($Scope in $Final.Scope)
     If ('vCenter|Datacenter|Cluster|DSCluster|Host|VM|Network' -notmatch $Scope) {
         Write-Warning "Skipping test $TestName. Use -Verbose for more details"
         Write-Verbose 'Test files should be in a folder with one of the following names:'
-        Write-Verbose 'vCenter / Datacenter / Cluster / Host / VM / Network'
+        Write-Verbose 'vCenter / Datacenter / Cluster / DSCluster / Host / VM / Network'
         Write-Verbose 'This helps Vester determine which inventory object(s) to use during the test.'
         # Use continue to skip this test and go to the next loop iteration
         continue

--- a/Vester/Private/Template/VesterTemplate.Tests.ps1
+++ b/Vester/Private/Template/VesterTemplate.Tests.ps1
@@ -85,11 +85,13 @@ foreach($Scope in $Final.Scope)
         }
     }  
 
-    # Loops through each object in the inventory list for the specific scope
-    foreach($Object in $Inventory)
+    # Runs through each test file on the below objects in the currect scope
+    foreach($Test in $Tests)
     {
-        # Runs through each test file on the above objects in the currect scope
-        foreach($Test in $Tests)
+
+        # Loops through each object in the inventory list for the specific scope.
+        # It runs one test at a time against each $Object and moves onto the next test.
+        foreach($Object in $Inventory)
         {
             Write-Verbose "Processing test file $Test"
             $TestName = Split-Path $Test -Leaf

--- a/Vester/Private/Template/VesterTemplate.Tests.ps1
+++ b/Vester/Private/Template/VesterTemplate.Tests.ps1
@@ -85,7 +85,7 @@ foreach($Scope in $Final.Scope)
         }
     }  
 
-    # Runs through each test file on the below objects in the currect scope
+    # Runs through each test file on the below objects in the current scope
     foreach($Test in $Tests)
     {
 

--- a/Vester/Private/Template/VesterTemplate.Tests.ps1
+++ b/Vester/Private/Template/VesterTemplate.Tests.ps1
@@ -106,7 +106,6 @@ foreach($Scope in $Final.Scope)
 			# It runs one test at a time against each $Object and moves onto the next test.
 			foreach($Object in $Inventory)
 			{
-
 				It -Name "$Scope $($Object.Name) - $Title" -Test {
 					Try {
 						# "& $Actual" is running the first script block to compare to $Desired

--- a/Vester/Private/Template/VesterTemplate.Tests.ps1
+++ b/Vester/Private/Template/VesterTemplate.Tests.ps1
@@ -22,18 +22,50 @@ Param(
     [switch]$Remediate
 )
 
-# Process .Vester.ps1 files one at a time
-ForEach ($Test in $TestFiles) {
-    Write-Verbose "Processing test file $Test"
-    $TestName = Split-Path $Test -Leaf
-    $Scope = Split-Path (Split-Path $Test -Parent) -Leaf
+# Gets the scope, the objects for the scope and their requested test files
+$Scopes = Split-Path (Split-Path $TestFiles -Parent) -Leaf | Select -Unique
+$Final = @()
+$InventoryList = @()
+$Datacenter = Get-Datacenter -Name $cfg.scope.datacenter -Server $cfg.vcenter.vc
+foreach($Scope in $Scopes)
+{
+    Write-Verbose "Processing $Scope"
+    Remove-Variable InventoryList -ErrorAction SilentlyContinue # Makes sure the variable is always fresh
+    # Use $Scope (parent folder) to get the correct objects to test against
+    # If changing values here, update the "$Scope -notmatch" test below as well
+    $InventoryList = switch ($Scope) {
+        'vCenter'    {$cfg.vcenter.vc}
+        'Datacenter' {$Datacenter}
+        'Cluster'    {$Datacenter | Get-Cluster -Name $cfg.scope.cluster}
+        'DSCluster'  {$Datacenter | Get-DatastoreCluster -Name $cfg.scope.dscluster}
+        'Host'       {$Datacenter | Get-Cluster -Name $cfg.scope.cluster | Get-VMHost -Name $cfg.scope.host}
+        'VM'         {$Datacenter | Get-Cluster -Name $cfg.scope.cluster | Get-VM -Name $cfg.scope.vm}
+        'Network'    {$Datacenter | Get-VDSwitch -Name $cfg.scope.vds}
+    }
+
+    $ScopeObj = [pscustomobject] @{
+        'Scope'         = $Scope
+        'InventoryList' = $InventoryList
+        'TestFiles'     = $TestFiles | Where-Object { (Split-Path (Split-Path $_ -Parent) -Leaf) -eq $Scope }
+    }
+    if (($ScopeObj.InventoryList -ne $NULL) -and ($ScopeObj.TestFiles -ne $NULL)){
+        $Final += $ScopeObj
+    }
+}
+
+# Loops through each Scope
+foreach($Scope in $Final.Scope)
+{
+    # Pulling the inventory and test files for this scope
+    $Inventory = ($Final | Where-Object { $_.Scope -eq $Scope }).InventoryList
+    $Tests = ($Final | Where-Object { $_.Scope -eq $Scope }).TestFiles
 
     # The parent folder must be one of these names, to help with $Object scoping below
     # If adding here, also needs to be added to the switch below
-    If ($Scope -notmatch 'vCenter|Datacenter|Cluster|DSCluster|Host|VM|Network') {
+    If ('vCenter|Datacenter|Cluster|DSCluster|Host|VM|Network' -notmatch $Scope) {
         Write-Warning "Skipping test $TestName. Use -Verbose for more details"
         Write-Verbose 'Test files should be in a folder with one of the following names:'
-        Write-Verbose 'vCenter / Datacenter / Cluster / DSCluster / Host / VM / Network'
+        Write-Verbose 'vCenter / Datacenter / Cluster / Host / VM / Network'
         Write-Verbose 'This helps Vester determine which inventory object(s) to use during the test.'
         # Use continue to skip this test and go to the next loop iteration
         continue
@@ -53,63 +85,57 @@ ForEach ($Test in $TestFiles) {
         }
     }
 
-    Describe -Name "$Scope Configuration: $TestName" -Fixture {
-        # Pull in $Title/$Description/$Desired/$Type/$Actual/$Fix from the test file
-        . $Test
+    If (($Final | Where-Object { $_.Scope -eq $Scope }).InventoryList -eq $null) {
+        Write-Verbose "No objects found in scope $Scope, skipping tests"
+        # Use continue to skip this test and go to the next loop iteration
+        continue
+    }    
 
-        # Pump the brakes if the config value is $null
-        If ($Desired -eq $null) {
-            Write-Verbose "Due to null config value, skipping test $TestName"
-            # Use continue to skip this test and go to the next loop iteration
-            continue
-        } Else {
-            $Datacenter = Get-Datacenter -Name $cfg.scope.datacenter -Server $cfg.vcenter.vc
-            # Use $Scope (parent folder) to get the correct objects to test against
-            # If changing values here, update the "$Scope -notmatch" test above as well
-            $InventoryList = switch ($Scope) {
-                'vCenter'    {$cfg.vcenter.vc}
-                'Datacenter' {$Datacenter}
-                'Cluster'    {$Datacenter | Get-Cluster -Name $cfg.scope.cluster}
-                'DSCluster'  {$Datacenter | Get-DatastoreCluster -Name $cfg.scope.dscluster}
-                'Host'       {$Datacenter | Get-Cluster -Name $cfg.scope.cluster | Get-VMHost -Name $cfg.scope.host}
-                'VM'         {$Datacenter | Get-Cluster -Name $cfg.scope.cluster | Get-VM -Name $cfg.scope.vm}
-                'Network'    {$Datacenter | Get-VDSwitch -Name $cfg.scope.vds}
-            }
-        } #If Desired
+    # Loops through each object in the inventory list for the specific scope
+    foreach($Object in $Inventory)
+    {
+        # Runs through each test file on the above objects in the currect scope
+        foreach($Test in $Tests)
+        {
+            Write-Verbose "Processing test file $Test"
+            $TestName = Split-Path $Test -Leaf
 
-        If ($InventoryList -eq $null) {
-            Write-Verbose "No objects found in scope $Scope, skipping test $TestName"
-            # Use continue to skip this test and go to the next loop iteration
-            continue
-        }
+            Describe -Name "$Scope Configuration: $TestName" -Fixture {
+                # Pull in $Title/$Description/$Desired/$Type/$Actual/$Fix from the test file
+                . $Test
 
-        ForEach ($Object in $InventoryList) {
-            Write-Verbose "Processing $($Object.Name) within test $TestName"
+                # Pump the brakes if the config value is $null
+                If ($Desired -eq $null) {
+                    Write-Verbose "Due to null config value, skipping test $TestName"
+                    # Use continue to skip this test and go to the next loop iteration
+                    continue
+                }
 
-            It -Name "$Scope $($Object.Name) - $Title" -Test {
-                Try {
-                    # "& $Actual" is running the first script block to compare to $Desired
-                    # The comparison should be empty
-                    # (meaning everything is the same, as expected)
-                    Compare-Object -ReferenceObject $Desired -DifferenceObject (& $Actual -as $Type) |
-                        Should BeNullOrEmpty
-                } Catch {
-                    # If the comparison found something different,
-                    # Then check if we're going to fix it
-                    If ($Remediate) {
-                        Write-Warning -Message $_
-                        # -WhatIf support wraps the command that would change values
-                        If ($PSCmdlet.ShouldProcess("vCenter '$($cfg.vcenter.vc)' - $Scope '$Object'", "Set '$Title' value to '$Desired'")) {
-                            Write-Warning -Message "Remediating $Object"
-                            # Execute the $Fix script block
-                            & $Fix
+                It -Name "$Scope $($Object.Name) - $Title" -Test {
+                    Try {
+                        # "& $Actual" is running the first script block to compare to $Desired
+                        # The comparison should be empty
+                        # (meaning everything is the same, as expected)
+                        Compare-Object -ReferenceObject $Desired -DifferenceObject (& $Actual -as $Type) |
+                            Should BeNullOrEmpty
+                    } Catch {
+                        # If the comparison found something different,
+                        # Then check if we're going to fix it
+                        If ($Remediate) {
+                            Write-Warning -Message $_
+                            # -WhatIf support wraps the command that would change values
+                            If ($PSCmdlet.ShouldProcess("vCenter '$($cfg.vcenter.vc)' - $Scope '$Object'", "Set '$Title' value to '$Desired'")) {
+                                Write-Warning -Message "Remediating $Object"
+                                # Execute the $Fix script block
+                                & $Fix
+                            }
+                        } Else {
+                            # -Remediate is not active, so just report the error
+                            throw $_
                         }
-                    } Else {
-                        # -Remediate is not active, so just report the error
-                        throw $_
-                    }
-                } #Try/Catch
-            } #It
-        } #ForEach Object
-    } #Describe
-} #ForEach Test
+                    } #Try/Catch
+                } #It
+            } #Describe                    
+        }#Foreach Testfiles
+    }#Foreach $Final.InventoryList
+}#Foreach Scopes


### PR DESCRIPTION
I added jpsider's suggestion

- _Move the check for null items in the foreach ($scope) loop.
- #Only add valid ScopeObj's
- if (($ScopeObj.InventoryList -ne $NULL) -and ($ScopeObj.TestFiles -ne $NULL)){
- $Final += $ScopeObj
- }
- This will only add populated values to the new collection._

I did not add the other suggestions. I think the way where you get the object and loop through each test is how it is currently.

I'm not sure that we need these lines anymore:
```
    # The parent folder must be one of these names, to help with $Object scoping below
    # If adding here, also needs to be added to the switch below
    If ('vCenter|Datacenter|Cluster|DSCluster|Host|VM|Network' -notmatch $Scope) {
        Write-Warning "Skipping test $TestName. Use -Verbose for more details"
        Write-Verbose 'Test files should be in a folder with one of the following names:'
        Write-Verbose 'vCenter / Datacenter / Cluster / Host / VM / Network'
        Write-Verbose 'This helps Vester determine which inventory object(s) to use during the test.'
        # Use continue to skip this test and go to the next loop iteration
        continue
    }
```

and

```
    If (($Final | Where-Object { $_.Scope -eq $Scope }).InventoryList -eq $null) {
        Write-Verbose "No objects found in scope $Scope, skipping tests"
        # Use continue to skip this test and go to the next loop iteration
        continue
    }    
```

mainly because of lines 51-53