### PR TITLE
Issue# 105 - Ported VM: Snapshot-Retention

### DIFF
--- a/Vester/Tests/VM/Snapshot-Retention.Vester.ps1
+++ b/Vester/Tests/VM/Snapshot-Retention.Vester.ps1
@@ -16,15 +16,27 @@ $Type = 'int'
 # The command(s) to pull the actual value for comparison
 # $Object will scope to the folder this test is in (Cluster, Host, etc.)
 [ScriptBlock]$Actual = {
-	$Snapshots = $Object | Get-Snapshot | Where-Object { $_.Created -lt (Get-Date).AddDays(-$Desired) }
-	if($Snapshots)
+	# If a desired retention period has not been set
+	if(!$Desired)
 	{
-		Write-Warning "Snapshot(s) older than $Desired have been found."
 		Write-Output 999
 	}
 	else
 	{
-		$Desired
+		$Snapshots = $Object | Get-Snapshot | Where-Object { $_.Created -lt (Get-Date).AddDays(-$Desired) }
+		# If a snapshot older than the retention period is found
+		# output a random number so it will trigger a test failure
+		if($Snapshots)
+		{
+			Write-Warning "Snapshot(s) older than $Desired have been found."
+			Write-Output (999 - $Desired)
+		}
+		# If a snapshot retention violation is not found
+		# output $Desired so the test will succeed
+		else
+		{
+			$Desired
+		}
 	}
 }
 

--- a/Vester/Tests/VM/Snapshot-Retention.Vester.ps1
+++ b/Vester/Tests/VM/Snapshot-Retention.Vester.ps1
@@ -1,0 +1,35 @@
+# Test file for the Vester module - https://github.com/WahlNetwork/Vester
+# Called via Invoke-Pester VesterTemplate.Tests.ps1
+
+# Test title, e.g. 'DNS Servers'
+$Title = 'VM Snapshot Retention'
+
+# Test description: How New-VesterConfig explains this value to the user
+$Description = 'Deletes snapshots older than the retention period'
+
+# The config entry stating the desired values
+$Desired = $cfg.vm.snapshotretention
+
+# The test value's data type, to help with conversion: bool/string/int
+$Type = 'int'
+
+# The command(s) to pull the actual value for comparison
+# $Object will scope to the folder this test is in (Cluster, Host, etc.)
+[ScriptBlock]$Actual = {
+	$Snapshots = $Object | Get-Snapshot | Where-Object { $_.Created -lt (Get-Date).AddDays(-$Desired) }
+	if($Snapshots)
+	{
+		Write-Warning "Snapshot(s) older than $Desired have been found."
+		Write-Output 999
+	}
+	else
+	{
+		$Desired
+	}
+}
+
+# The command(s) to match the environment to the config
+# Use $Object to help filter, and $Desired to set the correct value
+[ScriptBlock]$Fix = {
+	$Object | Get-Snapshot | Where-Object { $_.Created -lt (Get-Date).AddDays(-$Desired) } | Remove-Snapshot -ErrorAction Stop -Confirm:$FALSE
+}


### PR DESCRIPTION
This one wasn't too bad, I just had to think for a moment on how to put the retention time in the Config.json file.

The first time New-VesterConfig is run, it will default to '999'. I hope no one has any snapshots that old, but they can go into the Config.json and change '999' to the appropriate retention time.