### PR TITLE
Issue #116 - Update to ensure $object.name is correct for vCenter

### DIFF
--- a/Vester/Private/Template/VesterTemplate.Tests.ps1
+++ b/Vester/Private/Template/VesterTemplate.Tests.ps1
@@ -67,7 +67,7 @@ ForEach ($Test in $TestFiles) {
             # Use $Scope (parent folder) to get the correct objects to test against
             # If changing values here, update the "$Scope -notmatch" test above as well
             $InventoryList = switch ($Scope) {
-                'vCenter'    {$global:DefaultVIServer}
+                'vCenter'    {$global:DefaultVIServer | where-object {$_.name -like "$($cfg.vcenter.vc)"}}
                 'Datacenter' {$Datacenter}
                 'Cluster'    {$Datacenter | Get-Cluster -Name $cfg.scope.cluster}
                 'DSCluster'  {$Datacenter | Get-DatastoreCluster -Name $cfg.scope.dscluster}

--- a/Vester/Private/Template/VesterTemplate.Tests.ps1
+++ b/Vester/Private/Template/VesterTemplate.Tests.ps1
@@ -67,7 +67,7 @@ ForEach ($Test in $TestFiles) {
             # Use $Scope (parent folder) to get the correct objects to test against
             # If changing values here, update the "$Scope -notmatch" test above as well
             $InventoryList = switch ($Scope) {
-                'vCenter'    {$cfg.vcenter.vc}
+                'vCenter'    {$global:DefaultVIServer}
                 'Datacenter' {$Datacenter}
                 'Cluster'    {$Datacenter | Get-Cluster -Name $cfg.scope.cluster}
                 'DSCluster'  {$Datacenter | Get-DatastoreCluster -Name $cfg.scope.dscluster}


### PR DESCRIPTION
I chose to only update this in one location in this script. It will return the correct name in the console and xml output. The other areas with $cfg.vcenter.vc do not require this change to be functional.