### PR TITLE
Fixing issue with wrong parameter in MTUsize test.

### DIFF
--- a/Vester/Tests/Network/VDS-MTUsize.Vester.ps1
+++ b/Vester/Tests/Network/VDS-MTUsize.Vester.ps1
@@ -22,5 +22,5 @@ $Type = 'int'
 # The command(s) to match the environment to the config
 # Use $Object to help filter, and $Desired to set the correct value
 [ScriptBlock]$Fix = {
-    Set-VDSwitch $Object -LinkDiscoveryProtocol $Desired -Confirm:$FALSE -ErrorAction Stop
+    Set-VDSwitch $Object -Mtu $Desired -Confirm:$FALSE -ErrorAction Stop
 }


### PR DESCRIPTION
The VDS-MTUsize test was setting the 'LinkDiscoveryProtocol' parameter not the 'Mtu' parameter in the $Fix block. Updated to use the 'Mtu' parameter.