### PR TITLE
Clarify messages for failed tests

### DIFF
--- a/Vester/Private/Template/VesterTemplate.Tests.ps1
+++ b/Vester/Private/Template/VesterTemplate.Tests.ps1
@@ -112,7 +112,14 @@ foreach($Scope in $Final.Scope)
 							}
 						} Else {
 							# -Remediate is not active, so just report the error
-							throw $_
+							$Message = @(
+                                "Desired:   [$($Desired.gettype())]$Desired"
+                                "Actual:    [$($(& $Actual).gettype())]$(& $Actual)"
+                                "Synopsis:  $Description"
+                                "Link:      https://wahlnetwork.github.io/Vester/reference/tests/$Scope/$($Title.replace(' ','-').replace(':','')).html"
+                                "Test File: $Test"
+                            ) -join "`n"
+                            Throw $Message
 						}
 					} #Try/Catch
 				} #It


### PR DESCRIPTION
The existing error messages for failed tests did not give much information
to admins or engineers reviewing the test results, simply indicating a
failure.

The update included here causes the failed test to return information on:

1. The desired value, with the appropriate type in `[]` before it.
2. The actual value discovered, with the appropriate type in `[]` before it.
3. The synopsis of the test that was run.
4. A link to the online help for the test that failed.
5. The path to the test file on the system where the test was run so that
the engineer can investigate the tests directly if necessary.

This resolves #155 by including useful information in the test failures.