### PR TITLE
Update Vester to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,27 +7,27 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
 
-## [Unreleased]
+## [1.2.0] - 2017-08-21
 Dropped some long overdue documentation updates. New URL: https://wahlnetwork.github.io/Vester
 
 ### Added
 - Online documentation at https://wahlnetwork.github.io/Vester
-  - #158:
+  - [#158][issue-158]:
     - Docs migrated from .rst to .md
     - Use PlatyPS to include current cmdlet-based help
     - Enable automated updates w/ new project build script
-  - Docs output to branch "gh-pages", which powers GitHub Pages at the new URL (#160)
+  - Docs output to branch "gh-pages", which powers GitHub Pages at the new URL ([#160][issue-160])
   - Renders the old readthedocs URL obsolete
-- New function Get-VesterTest (#157)
-  - A glorified Get-ChildItem for Vester test files (*.Vester.ps1)
+- New function Get-VesterTest ([#157][issue-157])
+  - A glorified Get-ChildItem for Vester test files (`*.Vester.ps1`)
   - Default path gathers all tests included with the module
   - Filter by Name or Scope (like "Cluster")
   - Exposes test details, like "Description", for simple user reference
 
 ### Changed
-- Changed the readme (and all references to the old docs site) to the new URL (#164)
+- Changed the readme (and all references to the old docs site) to the new URL ([#164][issue-164])
 
-### Much :heart:
+### Much ❤
 [@michaeltlombardi](https://github.com/michaeltlombardi)
 
 
@@ -123,3 +123,7 @@ Published just to reserve the name on the PowerShell Gallery. If you have this v
 [issue-119]: https://github.com/WahlNetwork/Vester/issues/119
 [issue-129]: https://github.com/WahlNetwork/Vester/issues/129
 [issue-154]: https://github.com/WahlNetwork/Vester/issues/154
+[issue-157]: https://github.com/WahlNetwork/Vester/issues/157
+[issue-158]: https://github.com/WahlNetwork/Vester/issues/158
+[issue-160]: https://github.com/WahlNetwork/Vester/issues/160
+[issue-164]: https://github.com/WahlNetwork/Vester/issues/164

--- a/Tests/Function/Get-VesterTest.Tests.ps1
+++ b/Tests/Function/Get-VesterTest.Tests.ps1
@@ -1,0 +1,5 @@
+﻿#Requires -Version 3 -Modules Pester
+
+Describe -Name 'Get-VesterTest unit tests' -Tag 'unit' {
+    # lol I should be tests but my author is too lazy
+}

--- a/Tests/Module/Vester.Tests.ps1
+++ b/Tests/Module/Vester.Tests.ps1
@@ -27,7 +27,7 @@ Describe 'Check module files for breaking changes' {
         It 'Static .psd1 values have not changed' {
             $manifest.RootModule | Should BeExactly 'Vester.psm1'
             $manifest.Name | Should BeExactly 'Vester'
-            $manifest.Version -as [Version] | Should BeGreaterThan '1.0.1'
+            $manifest.Version -as [Version] | Should BeGreaterThan '1.1.0'
             $manifest.Guid | Should BeExactly 'cd038486-b669-4edb-a66d-bfe94c61b011'
             $manifest.Author | Should BeExactly 'Chris Wahl'
             $manifest.CompanyName | Should BeExactly 'Community'

--- a/Vester/Vester.psd1
+++ b/Vester/Vester.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Vester.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.1.0'
+ModuleVersion = '1.2.0'
 
 # ID used to uniquely identify this module
 GUID = 'cd038486-b669-4edb-a66d-bfe94c61b011'
@@ -114,112 +114,7 @@ PrivateData = @{
         # ExternalModuleDependencies = @()
 
         # ReleaseNotes of this module
-        ReleaseNotes = @'
-## [Unreleased]
-Dropped some long overdue documentation updates. New URL: https://wahlnetwork.github.io/Vester
-
-### Added
-- Online documentation at https://wahlnetwork.github.io/Vester
-  - #158:
-    - Docs migrated from .rst to .md
-    - Use PlatyPS to include current cmdlet-based help
-    - Enable automated updates w/ new project build script
-  - Docs output to branch "gh-pages", which powers GitHub Pages at the new URL (#160)
-  - Renders the old readthedocs URL obsolete
-- New function Get-VesterTest (#157)
-  - A glorified Get-ChildItem for Vester test files (*.Vester.ps1)
-  - Default path gathers all tests included with the module
-  - Filter by Name or Scope (like "Cluster")
-  - Exposes test details, like "Description", for simple user reference
-
-### Changed
-- Changed the readme (and all references to the old docs site) to the new URL (#164)
-
-### Much :heart:
-[@michaeltlombardi](https://github.com/michaeltlombardi)
-
-
-## [1.1.0] - 2017-06-15
-I learned that we need to publish releases far more often. :)
-
-### Added
-- New scope for datastore clusters: "DSCluster"
-- New [DSCluster tests](https://github.com/WahlNetwork/Vester/tree/0a8b87807e60606fe3006a65bbb429958a122d34/Vester/Tests/DSCluster):
-  - AutoOverride-IoLoadBalance
-  - AutoOverride-PolicyEnforcement
-  - AutoOverride-RuleEnforcement
-  - AutoOverride-SpaceLoadBalance
-  - AutoOverride-VmEvacuation
-  - IO-Latency
-  - IO-LoadImbalanceThreshold
-  - IO-ResIopsThreshold
-  - IO-ResPercentThreshold
-  - IO-ResThresholdMode
-  - IOLoadBalance
-  - LoadBalance-Interval
-  - SDRS-AutomationLevel
-  - SDRS-DefaultVMAffinity
-  - Space-FreespaceTheshold
-  - Space-ThresholdMode
-  - Space-UtilDiffMin
-  - SpaceUtilPercent
-- Some new tests were written, and others were ported from the old test format (prior to Vester 1.0's module life)
-- New [vCenter tests](https://github.com/WahlNetwork/Vester/tree/0a8b87807e60606fe3006a65bbb429958a122d34/Vester/Tests/vCenter):
-  - SMTP-Sender
-  - SMTP-Server
-  - VC-EventMaxAge
-  - VC-EventMaxAgeEnabled
-  - VC-TaskMaxAge
-  - VC-TaskMaxAgeEnabled
-- New [ESXi Host tests](https://github.com/WahlNetwork/Vester/tree/0a8b87807e60606fe3006a65bbb429958a122d34/Vester/Tests/Host):
-  - Advanced-Kernel-iovDisableIR
-  - BPDU-Filter
-  - Disk-MaxLUN
-  - NetDump-Settings
-  - NetDump-SettingsEnable
-  - NTP-Service
-  - NTP-Service-Policy
-  - SSH-Service-Policy
-- New [VM tests](https://github.com/WahlNetwork/Vester/tree/0a8b87807e60606fe3006a65bbb429958a122d34/Vester/Tests/VM):
-  - Boot-Delay
-  - CPU-Reservation
-  - Isolation-DeviceConnectable
-  - Isolation-DeviceEdit
-  - Memory-Reservation
-  - RemoteConsole-VNC
-  - Snapshot-Retention
-  - Sync-TimeSettings
-  - Tools-HostInfoAccess
-  - Tools-SetInfo-SizeLimit
-- New [VDS Network tests](https://github.com/WahlNetwork/Vester/tree/0a8b87807e60606fe3006a65bbb429958a122d34/Vester/Tests/Network):
-  - VDS-LinkOperation
-  - VDS-MTUsize
-  - VDS-Teaming-HealthCheck
-  - VDS-VlanMTU-HealthCheck
-
-### Changed
-- #114/#115: `Invoke-Vester` is **more than twice as fast** now! We removed repeated `Get` calls within private file `VesterTemplate.Tests.ps1`. Big thanks to @Midacts/@jpsider/@jonneedham for collaborating on this.
-- #118/#119: `Config.json` files now sort their settings within each scope.
-
-### Fixed
-- #90: `Invoke-Vester -Test $TestList` should execute all tests in the array, instead of just the final one after ignoring the rest. Now they do again.
-- #99: Re-implemented `-PassThru` on `Invoke-Vester`.
-- #116/#129: The name of the active vCenter connection was not being reported properly.
-- Cleaned up VM test files:
-  - Tools-DiskWiperDisable
-  - Tools-HGFS-ServerDisable
-
-### Much :heart:
-[@jeffgreenca](https://github.com/jeffgreenca) [@haberstrohr](https://github.com/haberstrohr) [@jonneedham](https://github.com/jonneedham) [@Midacts](https://github.com/Midacts) [@jpsider](https://github.com/jpsider)
-
-
-## [1.0.1] - 2017-02-28
-Initial availability as a PowerShell module
-
-
-## [1.0.0] - 2016-11-10 [YANKED]
-Published just to reserve the name on the PowerShell Gallery. If you have this version, please update!
-'@
+        ReleaseNotes = 'https://github.com/WahlNetwork/Vester/blob/master/CHANGELOG.md'
     } # End of PSData hashtable
 
 } # End of PrivateData hashtable


### PR DESCRIPTION
This version updates the documentation (#158 & friends) and introduces `Get-VesterTest` (#166).

I'm publishing on the PowerShell Gallery tonight so it'll be available for VMworld Hackathon festivities.

This commit removes the release notes from the .psd1 file, and instead provides the URI to `CHANGELOG.md` on the GitHub repo. That way we don't have to duplicate efforts.

I have no comment about the awesome test suite that was added.