### PR TITLE
Set JSON Convert Depth to 5

### DIFF
--- a/Vester/Public/New-VesterConfig.ps1
+++ b/Vester/Public/New-VesterConfig.ps1
@@ -290,7 +290,7 @@ function New-VesterConfig {
 
     Write-Verbose "Creating config file at $OutputFolder\Config.json"
     Try {
-        $config | ConvertTo-Json | Out-File $OutputFolder\Config.json -ErrorAction Stop
+        $config | ConvertTo-Json -depth 5 | Out-File $OutputFolder\Config.json -ErrorAction Stop
         Write-Host "`nConfig file created at " -ForegroundColor Green -NoNewline
         Write-Host "$OutputFolder\Config.json"
         Write-Host 'Edit the file manually to change any displayed values.'


### PR DESCRIPTION
This modifies this new-vesterconfig script's convertto-json command to use a -depth of 5 instead of the default 2, in order to support more complex data structures in the config files.