### PR TITLE
Add Ability to have $Desired be defined as a ScriptBlock for more interesting/complex tests

### DIFF
--- a/Vester/Private/Extract-VestDetails.ps1
+++ b/Vester/Private/Extract-VestDetails.ps1
@@ -10,11 +10,15 @@ function Extract-VestDetails {
 
     # Create $Title/$Description/$Type/$Actual/$Fix from the test file
     . $Object.FullName
-                        
-    # That doesn't work to find $Desired's value, so do it here
-    $Desired = ((Select-String -Path $Object.FullName -Pattern 'Desired \=').Line -split ' ')[-1]
-
-    # Output all properties for capturing in a $Vest variable
+    
+    #account for $Desired possibly being a script block. If it is don't do anything special (treat like $Actual)
+    # if not get the value as before
+    if ( -Not (Select-String -Path $Object.FullName -Pattern '\$Desired \=').Line.ToLower().Contains('scriptblock') ){
+        # That doesn't work to find $Desired's value, so do it here
+        $Desired = ((Select-String -Path $Object.FullName -Pattern '\$Desired \=').Line -split ' ')[-1]
+   }
+ 
+   # Output all properties for capturing in a $Vest variable
     [PSCustomObject]@{
         # Add a custom type name for this object
         # Used with DefaultDisplayPropertySet

--- a/Vester/Private/Template/VesterTemplate.Tests.ps1
+++ b/Vester/Private/Template/VesterTemplate.Tests.ps1
@@ -98,7 +98,11 @@ foreach($Scope in $Final.Scope)
 						# The comparison should be empty
 						# (meaning everything is the same, as expected)
 						$Result = (& $Actual -as $Type)
-						Compare-Object -ReferenceObject $Desired -DifferenceObject $Result |
+                        #allow for $Desired to be a scriptblock vs simple value
+                        if ($Desired.GetType().name -eq 'scriptblock') {
+                            $Desired = (& $Desired -As $Type)
+                        }
+                        Compare-Object -ReferenceObject $Desired -DifferenceObject $Result |
 							Should BeNullOrEmpty
 					} Catch {
 						# If the comparison found something different,


### PR DESCRIPTION
This change allows for defining $Desired in a test as a ScriptBlock. 
- Update ```VesterTemplate.Tests.ps1```

I'm working on trying to write some tests around DRS Rules and needed a way to build an array of strings since I can't just get it from a single value. 

Signed-off-by: Carlos Tronco <cars@lostroncos.org>