### PR TITLE
Support running in PowerCLI Core Docker container

### DIFF
--- a/Vester/Private/Get-VesterChildItem.ps1
+++ b/Vester/Private/Get-VesterChildItem.ps1
@@ -11,33 +11,42 @@ function Get-VesterChildItem {
         $Simple
     )
 
+    # Determine path separater character for this platform
+    $sep = '\\'
+    If ($pwd.path.contains('/')) {
+      $sep = '/'
+    }
+
+    # cross-platform support
+    $Path = (Get-Item $Path).FullName
+
     Write-Verbose "[Get-VesterChildItem] $Path"
 
     If ($Scope -and $Name) {
         $Name | ForEach-Object {
             Get-ChildItem -Path $Path -Filter "$_.Vester.ps1" -File -Recurse |
                 Select-Object @{n='Name';e={($_.BaseName -split '\.')[0]}},
-                                @{n='Scope';e={($_.Directory -split '\\')[-1]}},
+                                @{n='Scope';e={($_.Directory -split $sep)[-1]}},
                                 FullName |
                 Where-Object Scope -in $Scope
         }
     } ElseIf ($Scope) {
         Get-ChildItem -Path $Path -Filter '*.Vester.ps1' -File -Recurse |
             Select-Object @{n='Name';e={($_.BaseName -split '\.')[0]}},
-                            @{n='Scope';e={($_.Directory -split '\\')[-1]}},
+                            @{n='Scope';e={($_.Directory -split $sep)[-1]}},
                             FullName |
             Where-Object Scope -in $Scope
     } ElseIf ($Name) {
         $Name | ForEach-Object {
             Get-ChildItem -Path $Path -Filter "$_.Vester.ps1" -File -Recurse |
                 Select-Object @{n='Name';e={($_.BaseName -split '\.')[0]}},
-                                @{n='Scope';e={($_.Directory -split '\\')[-1]}},
+                                @{n='Scope';e={($_.Directory -split $sep)[-1]}},
                                 FullName
         }
     } Else {
         Get-ChildItem -Path $Path -Filter '*.Vester.ps1' -File -Recurse |
             Select-Object @{n='Name';e={($_.BaseName -split '\.')[0]}},
-                            @{n='Scope';e={($_.Directory -split '\\')[-1]}},
+                            @{n='Scope';e={($_.Directory -split $sep)[-1]}},
                             FullName
     }
 }

--- a/Vester/Public/Get-VesterTest.ps1
+++ b/Vester/Public/Get-VesterTest.ps1
@@ -42,7 +42,7 @@
     Get-VesterTest -Path C:\Vester\
     -Path can also be pointed at a directory containing custom tests.
     Get-VesterTest will search here for all .Vester.ps1 files, recursively.
-    
+
     (Note that the immediate parent folder of all test files should have a
     name matching the test's intended scope, like "VM".)
 
@@ -78,10 +78,9 @@
         # If a directory, child .Vester.ps1 files are gathered recursively.
         [Parameter(ValueFromPipeline = $true)]
         [ValidateScript({
-            If ($_.FullName) {Test-Path $_.FullName}
-            Else {Test-Path $_}
+            Test-Path (Get-Item $_).FullName
         })]
-        [object[]]$Path = "$(Split-Path -Parent $PSScriptRoot)\Tests\",
+        [object[]]$Path = (Get-Item "$(Split-Path -Parent $PSScriptRoot)\Tests\").FullName,
 
         # Return only test files belonging to the specified Vester scope(s).
         # Vester determines test file scope by the name of its parent directory.
@@ -112,16 +111,15 @@
 
         # Construct empty array to throw file paths of tests into
         $TestFiles = New-Object 'System.Collections.Generic.List[PSCustomObject]'
-        
+
     }
 
     PROCESS {
         # Need to ForEach if multiple -Test locations
         ForEach ($TestPath in $Path) {
             # Gracefully handle FileSystemInfo objects (Get-Item / Get-ChildItem)
-            If ($TestPath.FullName) {
-                $TestPath = $TestPath.FullName
-            }
+            # and support cross-platform naming conventions
+            $TestPath = (Get-Item $TestPath).FullName
 
             If (Test-Path $TestPath -PathType Container) {
                 # If Test-Path finds a folder, get all *.Vester.ps1 files beneath it

--- a/Vester/Public/Invoke-Vester.ps1
+++ b/Vester/Public/Invoke-Vester.ps1
@@ -124,9 +124,13 @@
 
         ForEach ($ConfigFile in $Config) {
             # Gracefully handle Get-Item/Get-ChildItem
-            If ($ConfigFile.FullName) {
-                $ConfigFile = $ConfigFile.FullName
+            # Always pass thru Get-Item, to support cross-platform path conventions
+            If(Test-Path $ConfigFile) {
+                $ConfigFile = (Get-Item $ConfigFile).FullName
+            } else {
+                throw "Config file specified does not exist: '$ConfigFile'. Exiting"
             }
+
             Write-Verbose -Message "Processing Config file $ConfigFile"
 
             # Load the defined $cfg values to test
@@ -154,7 +158,7 @@
             #Build Pester Parameter Hashtable to splat
             $Pester_Params = @{
                 Script = @{
-                    Path = "$(Split-Path -Parent $PSScriptRoot)\Private\Template\VesterTemplate.Tests.ps1"
+                    Path = (Get-Item "$(Split-Path -Parent $PSScriptRoot)\Private\Template\VesterTemplate.Tests.ps1").FullName
                     Parameters = @{
                         Cfg       = $cfg
                         TestFiles = $Test

--- a/Vester/Vester.psd1
+++ b/Vester/Vester.psd1
@@ -50,8 +50,7 @@ PowerShellVersion = '3.0'
 # Modules that must be imported into the global environment prior to importing this module
 RequiredModules = @(
     @{ModuleName = 'Pester'; ModuleVersion = '3.4.3'},
-    @{ModuleName = 'VMware.VimAutomation.Core'; ModuleVersion = '6.5.1'},
-    @{ModuleName = 'VMware.VumAutomation'; ModuleVersion = '6.5.1'}
+    @{ModuleName = 'VMware.VimAutomation.Core'; ModuleVersion = '6.5.1'}
 )
 
 # Assemblies that must be loaded prior to importing this module


### PR DESCRIPTION
See #206 for more information. 

In part, this uses Get-Item to normalize path separators, which works even if when `/` and `\` are mixed, as in this example:
```
C:\tools> (Get-Item ".\neovim\Neovim\bin\nvim.exe").FullName
C:\tools\neovim\Neovim\bin\nvim.exe
C:\tools> (Get-Item ".\neovim\Neovim/bin/nvim.exe").FullName
C:\tools\neovim\Neovim\bin\nvim.exe
```

It also removes the explicit load of VMware.VumAutomation (not supported in PowerCLI core yet)